### PR TITLE
Made reputation message field contents in a mobile-suitable order

### DIFF
--- a/src/main/java/de/chojo/repbot/listener/MessageListener.java
+++ b/src/main/java/de/chojo/repbot/listener/MessageListener.java
@@ -141,7 +141,7 @@ public class MessageListener extends ListenerAdapter {
 
         for (var i = 0; i < members.size(); i++) {
             targets.put(requestEmojis[i], members.get(i));
-            (i % 2 == 0 ? first : second).add(requestEmojis[i] + " " + members.get(i).getAsMention());
+            (i <= members.size()/2 + members.size()%2 ? first : second).add(requestEmojis[i] + " " + members.get(i).getAsMention());
         }
 
         var builder = new LocalizedEmbedBuilder(localizer, message.getGuild())

--- a/src/main/java/de/chojo/repbot/listener/MessageListener.java
+++ b/src/main/java/de/chojo/repbot/listener/MessageListener.java
@@ -141,7 +141,7 @@ public class MessageListener extends ListenerAdapter {
 
         for (var i = 0; i < members.size(); i++) {
             targets.put(requestEmojis[i], members.get(i));
-            (i <= members.size()/2 + members.size()%2 ? first : second).add(requestEmojis[i] + " " + members.get(i).getAsMention());
+            (i <= members.size() / 2 + members.size() % 2 ? first : second).add(requestEmojis[i] + " " + members.get(i).getAsMention());
         }
 
         var builder = new LocalizedEmbedBuilder(localizer, message.getGuild())


### PR DESCRIPTION
The fields are now sorted correctly on mobile and make a little bit more sense on PC.
2nd PR (feature/thank-embed-mobile -> origin/development)