### PR TITLE
Fix wrong order in request message embed

### DIFF
--- a/src/main/java/de/chojo/repbot/listener/MessageListener.java
+++ b/src/main/java/de/chojo/repbot/listener/MessageListener.java
@@ -37,7 +37,7 @@ public class MessageListener extends ListenerAdapter {
     private final GuildData guildData;
     private final ReputationData reputationData;
     private final MemberCacheManager memberCacheManager;
-    private final String[] requestEmojis = new String[] {"1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣", "🔟"};
+    private final String[] requestEmojis = new String[]{"1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣", "🔟"};
     private final ReactionListener reactionListener;
     private final Localizer localizer;
     private final ReputationManager reputationManager;
@@ -80,8 +80,8 @@ public class MessageListener extends ListenerAdapter {
         var prefix = settings.getPrefix().orElse(configuration.getDefaultPrefix());
         if (prefix.startsWith("re:")) {
             var compile = Pattern.compile(prefix.substring(3));
-            if(compile.matcher(message.getContentRaw()).find()) return;
-        }else {
+            if (compile.matcher(message.getContentRaw()).find()) return;
+        } else {
             if (message.getContentRaw().startsWith(prefix)) return;
         }
         if (message.getContentRaw().startsWith(settings.getPrefix().orElse(configuration.getDefaultPrefix()))) {
@@ -139,9 +139,9 @@ public class MessageListener extends ListenerAdapter {
         List<String> second = new ArrayList<>();
         Map<String, Member> targets = new LinkedHashMap<>();
 
-        for (var i = 0; i < members.size(); i++) {
+        for (var i = 1; i <= members.size(); i++) {
             targets.put(requestEmojis[i], members.get(i));
-            (i <= members.size() / 2 + members.size() % 2 ? first : second).add(requestEmojis[i] + " " + members.get(i).getAsMention());
+            (leftSide(i, members.size()) ? first : second).add(requestEmojis[i] + " " + members.get(i).getAsMention());
         }
 
         var builder = new LocalizedEmbedBuilder(localizer, message.getGuild())
@@ -162,5 +162,9 @@ public class MessageListener extends ListenerAdapter {
             voteMessage.addReaction("🗑️").queueAfter(i * 250L, TimeUnit.MILLISECONDS);
             voteMessage.delete().queueAfter(1, TimeUnit.MINUTES, e -> reactionListener.unregisterVote(voteMessage), err -> reactionListener.unregisterVote(voteMessage));
         });
+    }
+
+    private boolean leftSide(int num, int total) {
+        return num <= total / 2 + total % 2;
     }
 }

--- a/src/test/java/de/chojo/repbot/listener/MessageListenerTest.java
+++ b/src/test/java/de/chojo/repbot/listener/MessageListenerTest.java
@@ -1,0 +1,51 @@
+package de.chojo.repbot.listener;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class MessageListenerTest {
+
+    @Test
+    public void testFlip() {
+        var result = divide(1);
+        Assertions.assertEquals(1, result[0]);
+        Assertions.assertEquals(0, result[1]);
+
+        result = divide(2);
+        Assertions.assertEquals(1, result[0]);
+        Assertions.assertEquals(1, result[1]);
+
+        result = divide(3);
+        Assertions.assertEquals(2, result[0]);
+        Assertions.assertEquals(1, result[1]);
+
+        result = divide(4);
+        Assertions.assertEquals(2, result[0]);
+        Assertions.assertEquals(2, result[1]);
+
+        result = divide(5);
+        Assertions.assertEquals(3, result[0]);
+        Assertions.assertEquals(2, result[1]);
+
+        result = divide(6);
+        Assertions.assertEquals(3, result[0]);
+        Assertions.assertEquals(3, result[1]);
+
+        result = divide(7);
+        Assertions.assertEquals(4, result[0]);
+        Assertions.assertEquals(3, result[1]);
+    }
+
+    public int[] divide(int total) {
+        int left = 0, right = 0;
+        for (int i = 1; i <= total; i++) {
+            if (leftSide(i, total)) left++;
+            else right++;
+        }
+        return new int[]{left, right};
+    }
+
+    private boolean leftSide(int num, int total) {
+        return num <= total / 2 + total % 2;
+    }
+}


### PR DESCRIPTION
The numbers are divided in the wrong field currently. This is caused by an off by 1 mistake. Classic.