### PR TITLE
Feature/bot owner actions

### DIFF
--- a/src/main/java/de/chojo/repbot/ReputationBot.java
+++ b/src/main/java/de/chojo/repbot/ReputationBot.java
@@ -153,7 +153,6 @@ public class ReputationBot {
         var stateListener = new StateListener(dataSource);
         var voiceStateListener = new VoiceStateListener(dataSource);
         var logListener = LogListener.create(repBotWorker);
-        var internalCommandListener = new InternalCommandListener(configuration);
         repBotWorker.scheduleAtFixedRate(stateListener, 1, 12, TimeUnit.HOURS);
         repBotWorker.scheduleAtFixedRate(voiceStateListener, 2, 12, TimeUnit.HOURS);
         shardManager.addEventListener(
@@ -162,8 +161,10 @@ public class ReputationBot {
                 reactionListener,
                 reputatinoVoteListener,
                 voiceStateListener,
-                logListener,
-                internalCommandListener);
+                logListener);
+        if (configuration.baseSettings().isInternalCommands()) {
+            shardManager.addEventListener(new InternalCommandListener(configuration));
+        }
         var data = new GuildData(dataSource);
         var hubBuilder = CommandHub.builder(shardManager, configuration.baseSettings().defaultPrefix())
                 .receiveGuildCommands()

--- a/src/main/java/de/chojo/repbot/commands/Prefix.java
+++ b/src/main/java/de/chojo/repbot/commands/Prefix.java
@@ -73,7 +73,7 @@ public class Prefix extends SimpleCommand {
     }
 
     private boolean reset(MessageEventWrapper eventWrapper) {
-        final var response = changePrefix(eventWrapper.getGuild(), configuration.defaultPrefix());
+        final var response = changePrefix(eventWrapper.getGuild(), configuration.baseSettings().defaultPrefix());
         if (response != null) {
             eventWrapper.reply(response).queue();
         }
@@ -81,7 +81,7 @@ public class Prefix extends SimpleCommand {
     }
 
     private void reset(SlashCommandEvent event) {
-        final var response = changePrefix(event.getGuild(), configuration.defaultPrefix());
+        final var response = changePrefix(event.getGuild(), configuration.baseSettings().defaultPrefix());
         if (response != null) {
             event.reply(response).queue();
         }
@@ -134,7 +134,7 @@ public class Prefix extends SimpleCommand {
     }
 
     private boolean get(MessageEventWrapper eventWrapper) {
-        var prefix = data.getPrefix(eventWrapper.getGuild()).orElse(configuration.defaultPrefix());
+        var prefix = data.getPrefix(eventWrapper.getGuild()).orElse(configuration.baseSettings().defaultPrefix());
         eventWrapper.reply(eventWrapper.localize("command.prefix.show",
                 Replacement.create("PREFIX", prefix, Format.CODE))).queue();
         return true;

--- a/src/main/java/de/chojo/repbot/config/ConfigFile.java
+++ b/src/main/java/de/chojo/repbot/config/ConfigFile.java
@@ -1,6 +1,7 @@
 package de.chojo.repbot.config;
 
 import de.chojo.repbot.config.elements.Badges;
+import de.chojo.repbot.config.elements.BaseSettings;
 import de.chojo.repbot.config.elements.Botlist;
 import de.chojo.repbot.config.elements.Database;
 import de.chojo.repbot.config.elements.Links;
@@ -9,30 +10,20 @@ import de.chojo.repbot.config.elements.TestMode;
 
 @SuppressWarnings("FieldMayBeFinal")
 public class ConfigFile {
-    private String token = "";
-    private String defaultPrefix = "!";
+    private BaseSettings baseSettings = new BaseSettings();
     private Database database = new Database();
-    private boolean exclusiveHelp = false;
     private MagicImage magicImage = new MagicImage();
     private TestMode testMode = new TestMode();
     private Badges badges = new Badges();
     private Links links = new Links();
     private Botlist botlist = new Botlist();
 
-    public String token() {
-        return token;
-    }
-
-    public String defaultPrefix() {
-        return defaultPrefix;
+    public BaseSettings baseSettings() {
+        return baseSettings;
     }
 
     public Database database() {
         return database;
-    }
-
-    public boolean isExclusiveHelp() {
-        return exclusiveHelp;
     }
 
     public MagicImage magicImage() {

--- a/src/main/java/de/chojo/repbot/config/Configuration.java
+++ b/src/main/java/de/chojo/repbot/config/Configuration.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import de.chojo.repbot.config.elements.Badges;
+import de.chojo.repbot.config.elements.BaseSettings;
 import de.chojo.repbot.config.elements.Botlist;
 import de.chojo.repbot.config.elements.Database;
 import de.chojo.repbot.config.elements.Links;
@@ -84,21 +85,12 @@ public class Configuration {
         return Paths.get(home.toString(), property);
     }
 
-    // DELEGATES
-    public String token() {
-        return configFile.token();
-    }
-
-    public String defaultPrefix() {
-        return configFile.defaultPrefix();
-    }
-
     public Database database() {
         return configFile.database();
     }
 
-    public boolean isExclusiveHelp() {
-        return configFile.isExclusiveHelp();
+    public BaseSettings baseSettings() {
+        return configFile.baseSettings();
     }
 
     public MagicImage magicImage() {

--- a/src/main/java/de/chojo/repbot/config/elements/BaseSettings.java
+++ b/src/main/java/de/chojo/repbot/config/elements/BaseSettings.java
@@ -7,6 +7,7 @@ public class BaseSettings {
     private String token = "";
     private String defaultPrefix = "!";
     private boolean exclusiveHelp = false;
+    private boolean internalCommands = false;
     private List<Long> botOwner = new ArrayList<>();
 
     public String token() {
@@ -19,6 +20,10 @@ public class BaseSettings {
 
     public String defaultPrefix() {
         return defaultPrefix;
+    }
+
+    public boolean isInternalCommands() {
+        return internalCommands;
     }
 
     public boolean isExclusiveHelp() {

--- a/src/main/java/de/chojo/repbot/config/elements/BaseSettings.java
+++ b/src/main/java/de/chojo/repbot/config/elements/BaseSettings.java
@@ -1,0 +1,27 @@
+package de.chojo.repbot.config.elements;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BaseSettings {
+    private String token = "";
+    private String defaultPrefix = "!";
+    private boolean exclusiveHelp = false;
+    private List<Long> botOwner = new ArrayList<>();
+
+    public String token() {
+        return token;
+    }
+
+    public boolean isOwner(long id) {
+        return botOwner.contains(id);
+    }
+
+    public String defaultPrefix() {
+        return defaultPrefix;
+    }
+
+    public boolean isExclusiveHelp() {
+        return exclusiveHelp;
+    }
+}

--- a/src/main/java/de/chojo/repbot/listener/InternalCommandListener.java
+++ b/src/main/java/de/chojo/repbot/listener/InternalCommandListener.java
@@ -1,0 +1,46 @@
+package de.chojo.repbot.listener;
+
+import de.chojo.jdautil.parsing.Verifier;
+import de.chojo.repbot.config.Configuration;
+import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+
+public class InternalCommandListener extends ListenerAdapter {
+    private final Configuration configuration;
+
+    public InternalCommandListener(Configuration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public void onGuildMessageReceived(@NotNull GuildMessageReceivedEvent event) {
+        if (!configuration.baseSettings().isOwner(event.getAuthor().getIdLong())) return;
+        var args = event.getMessage().getContentRaw().replaceAll("\\s+", " ").split(" ");
+        if (args.length < 2) return;
+        var idRaw = Verifier.getIdRaw(args[0]);
+        if (idRaw.isEmpty()) return;
+        if (!idRaw.get().equals(event.getJDA().getSelfUser().getId())) return;
+
+        args = Arrays.copyOfRange(args, 1, args.length);
+
+        if ("upgrade".equalsIgnoreCase(args[0])) {
+            event.getMessage().reply("Starting upgrade. Will be back soon!").complete();
+            System.exit(20);
+            return;
+        }
+
+        if ("restart".equalsIgnoreCase(args[0])) {
+            event.getMessage().reply("Restarting. Will be back soon!").complete();
+            System.exit(10);
+            return;
+        }
+
+        if ("shutdown".equalsIgnoreCase(args[0])) {
+            event.getMessage().reply("Initializing shutdown. Good bye :c").complete();
+            System.exit(0);
+        }
+    }
+}

--- a/src/main/java/de/chojo/repbot/listener/MessageListener.java
+++ b/src/main/java/de/chojo/repbot/listener/MessageListener.java
@@ -71,14 +71,14 @@ public class MessageListener extends ListenerAdapter {
 
         var message = event.getMessage();
 
-        var prefix = settings.prefix().orElse(configuration.defaultPrefix());
+        var prefix = settings.prefix().orElse(configuration.baseSettings().defaultPrefix());
         if (prefix.startsWith("re:")) {
             var compile = Pattern.compile(prefix.substring(3));
             if (compile.matcher(message.getContentRaw()).find()) return;
         } else {
             if (message.getContentRaw().startsWith(prefix)) return;
         }
-        if (message.getContentRaw().startsWith(settings.prefix().orElse(configuration.defaultPrefix()))) {
+        if (message.getContentRaw().startsWith(settings.prefix().orElse(configuration.baseSettings().defaultPrefix()))) {
             return;
         }
 


### PR DESCRIPTION
This patch provides a small internal command listener.

This listener allows users which are listed as botowners in the config file to mention the bot with basic commands to restart, upgrade and stop the bot.

This works by returning exit codes, which can be used by an bash script which will do the requested stuff.
The upgrade functionality depends on some self implemented stuff, which needs to be done by everyone individually.

All this stuff should also not be used on docker setups, since it will probably break stuff. That's why the default setting for the listener itself is set to false.