### PR TITLE
Feature/improve gdpr data

### DIFF
--- a/src/main/java/de/chojo/repbot/data/GdprData.java
+++ b/src/main/java/de/chojo/repbot/data/GdprData.java
@@ -141,7 +141,7 @@ public class GdprData extends QueryFactoryHolder {
 
     public void markAsFailed(long user) {
         builder()
-                .query("UPDATE gdpr_log SET tries = tries + 1 where user_id = ?")
+                .query("UPDATE gdpr_log SET attemts = attemts + 1 where user_id = ?")
                 .paramsBuilder(stmt -> stmt.setLong(user))
                 .update()
                 .executeSync();

--- a/src/main/java/de/chojo/repbot/data/GdprData.java
+++ b/src/main/java/de/chojo/repbot/data/GdprData.java
@@ -141,7 +141,7 @@ public class GdprData extends QueryFactoryHolder {
 
     public void markAsFailed(long user) {
         builder()
-                .query("UPDATE gdpr_log SET attemts = attemts + 1 where user_id = ?")
+                .query("UPDATE gdpr_log SET attempts = attempts + 1 WHERE user_id = ?")
                 .paramsBuilder(stmt -> stmt.setLong(user))
                 .update()
                 .executeSync();

--- a/src/main/java/de/chojo/repbot/data/updater/SqlUpdater.java
+++ b/src/main/java/de/chojo/repbot/data/updater/SqlUpdater.java
@@ -15,7 +15,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 public class SqlUpdater {
     public static final int MAJOR = 1;
-    public static final int PATCH = 5;
+    public static final int PATCH = 6;
     private static final Logger log = getLogger(SqlUpdater.class);
     private final DataSource source;
     private final String versionTable;

--- a/src/main/resources/database/1/patch_6.sql
+++ b/src/main/resources/database/1/patch_6.sql
@@ -1,5 +1,5 @@
-alter table repbot_schema.gdpr_log
-    rename column tries to attemts;
+ALTER TABLE repbot_schema.gdpr_log
+    RENAME COLUMN tries TO attempts;
 
 DROP FUNCTION repbot_schema.aggregate_user_data(bigint);
 
@@ -42,26 +42,26 @@ BEGIN
              WHERE user_id_1 = _user_id
                 OR user_id_2 = _user_id
          ),
-         cleanup_tasks as (
-             select jsonb_agg(
+         cleanup_tasks AS (
+             SELECT jsonb_agg(
                             jsonb_build_object(
                                     'guild', guild_id,
                                     'user', user_id,
                                     'delete_after', delete_after::text
                                 )
-                        ) as cleanup
-             from repbot_schema.cleanup_schedule c
-             where c.user_id = _user_id
+                        ) AS cleanup
+             FROM repbot_schema.cleanup_schedule c
+             WHERE c.user_id = _user_id
          ),
-         gdpr_log as (
-             select jsonb_build_object(
+         gdpr_log AS (
+             SELECT jsonb_build_object(
                             'user', user_id,
                             'received', received,
-                            'attemts', attemts,
+                            'attemts', attempts,
                             'requested', requested
-                        ) as gdpr
-             from gdpr_log l
-             where l.user_id = _user_id
+                        ) AS gdpr
+             FROM gdpr_log l
+             WHERE l.user_id = _user_id
          )
     SELECT jsonb_pretty(
                    jsonb_build_object(

--- a/src/main/resources/database/1/patch_6.sql
+++ b/src/main/resources/database/1/patch_6.sql
@@ -57,7 +57,7 @@ BEGIN
              SELECT jsonb_build_object(
                             'user', user_id,
                             'received', received,
-                            'attemts', attempts,
+                            'attempts', attempts,
                             'requested', requested
                         ) AS gdpr
              FROM gdpr_log l

--- a/src/main/resources/database/1/patch_6.sql
+++ b/src/main/resources/database/1/patch_6.sql
@@ -1,0 +1,81 @@
+alter table repbot_schema.gdpr_log
+    rename column tries to attemts;
+
+DROP FUNCTION repbot_schema.aggregate_user_data(bigint);
+
+CREATE OR REPLACE FUNCTION repbot_schema.aggregate_user_data(_user_id BIGINT)
+    RETURNS TEXT
+    LANGUAGE plpgsql
+    COST 100
+AS
+$BODY$
+DECLARE
+    _result JSONB;
+BEGIN
+    WITH reputation AS (
+        SELECT jsonb_agg(
+                       jsonb_build_object(
+                               'guild', guild_id,
+                               'channel', channel_id,
+                               'donor', CASE WHEN donor_id = _user_id THEN _user_id END,
+                               'receiver', CASE WHEN receiver_id = _user_id THEN _user_id END,
+                               'message', message_id,
+                               'ref_message', ref_message_id,
+                               'cause', cause,
+                               'received', received::TEXT
+                           )
+                   ) AS rep
+        FROM repbot_schema.reputation_log l
+        WHERE l.receiver_id = _user_id
+           OR l.donor_id = _user_id
+    ),
+         voice_activity AS (
+             SELECT jsonb_agg(
+                            jsonb_build_object(
+                                    'guild', guild_id,
+                                    'user_1', CASE WHEN user_id_1 = _user_id THEN _user_id END,
+                                    'user_2', CASE WHEN user_id_2 = _user_id THEN _user_id END,
+                                    'seen', seen::TEXT
+                                )
+                        ) AS voice
+             FROM repbot_schema.voice_activity
+             WHERE user_id_1 = _user_id
+                OR user_id_2 = _user_id
+         ),
+         cleanup_tasks as (
+             select jsonb_agg(
+                            jsonb_build_object(
+                                    'guild', guild_id,
+                                    'user', user_id,
+                                    'delete_after', delete_after::text
+                                )
+                        ) as cleanup
+             from repbot_schema.cleanup_schedule c
+             where c.user_id = _user_id
+         ),
+         gdpr_log as (
+             select jsonb_build_object(
+                            'user', user_id,
+                            'received', received,
+                            'attemts', attemts,
+                            'requested', requested
+                        ) as gdpr
+             from gdpr_log l
+             where l.user_id = _user_id
+         )
+    SELECT jsonb_pretty(
+                   jsonb_build_object(
+                           'reputation', coalesce(rep, '[]'::JSONB),
+                           'voice_activity', coalesce(voice, '[]'::JSONB),
+                           'cleanup_tasks', coalesce(cleanup, '[]'::jsonb),
+                           'gdpr_log', coalesce(gdpr_log, '{}'::jsonb)
+                       )
+               )
+    FROM reputation,
+         voice_activity,
+         cleanup_tasks,
+         gdpr_log
+    INTO _result;
+    RETURN _result;
+END;
+$BODY$;

--- a/src/main/resources/database/1/patch_6.sql
+++ b/src/main/resources/database/1/patch_6.sql
@@ -47,7 +47,7 @@ BEGIN
                             jsonb_build_object(
                                     'guild', guild_id,
                                     'user', user_id,
-                                    'delete_after', delete_after::text
+                                    'delete_after', delete_after::TEXT
                                 )
                         ) AS cleanup
              FROM repbot_schema.cleanup_schedule c
@@ -56,26 +56,24 @@ BEGIN
          gdpr_log AS (
              SELECT jsonb_build_object(
                             'user', user_id,
-                            'received', received,
+                            'received', now()::TEXT,
                             'attempts', attempts,
                             'requested', requested
                         ) AS gdpr
-             FROM gdpr_log l
+             FROM repbot_schema.gdpr_log l
              WHERE l.user_id = _user_id
          )
-    SELECT jsonb_pretty(
-                   jsonb_build_object(
-                           'reputation', coalesce(rep, '[]'::JSONB),
-                           'voice_activity', coalesce(voice, '[]'::JSONB),
-                           'cleanup_tasks', coalesce(cleanup, '[]'::jsonb),
-                           'gdpr_log', coalesce(gdpr_log, '{}'::jsonb)
-                       )
+    SELECT jsonb_build_object(
+                   'reputation', coalesce(rep, '[]'::JSONB),
+                   'voice_activity', coalesce(voice, '[]'::JSONB),
+                   'cleanup_tasks', coalesce(cleanup, '[]'::JSONB),
+                   'gdpr_log', coalesce(gdpr, '{}'::JSONB)
                )
     FROM reputation,
          voice_activity,
          cleanup_tasks,
          gdpr_log
     INTO _result;
-    RETURN _result;
+    RETURN jsonb_pretty(_result);
 END;
 $BODY$;


### PR DESCRIPTION
Improve gdpr data.

Add data from cleanup schedule and gdpr log which are mandatory user bound data. These table will be cleared scheduled and only kept as long as needed. They will not be cleared on a gdpr request.

Added also pretty printing for the report string.