### PR TITLE
Improve scan command

### DIFF
--- a/src/main/java/de/chojo/repbot/commands/Scan.java
+++ b/src/main/java/de/chojo/repbot/commands/Scan.java
@@ -45,9 +45,9 @@ public class Scan extends SimpleCommand {
     private final ThreadGroup scanner = new ThreadGroup("Scanner");
     private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(SCAN_THREADS + 1,
             runnable -> {
-                var thr = new Thread(scanner, runnable);
-                thr.setUncaughtExceptionHandler((thread, err) -> log.error("Unhandled exception in Scanner Thread {}.", thread.getId(), err));
-                return thr;
+                var thread = new Thread(scanner, runnable);
+                thread.setUncaughtExceptionHandler((thr, err) -> log.error("Unhandled exception in Scanner Thread {}.", thr.getId(), err));
+                return thread;
             });
     private final GuildData guildData;
     private final ReputationData reputationData;

--- a/src/main/java/de/chojo/repbot/data/ReputationData.java
+++ b/src/main/java/de/chojo/repbot/data/ReputationData.java
@@ -102,6 +102,7 @@ public class ReputationData extends QueryFactoryHolder {
                         from
                             user_reputation
                         WHERE guild_id = ?
+                            AND reputation != 0
                         ORDER BY reputation DESC
                         OFFSET ?
                         LIMIT ?;


### PR DESCRIPTION
Improve the scan command by a bit.
It was possible that users gave reputation which were no longer on the guild.

Users with no reputation will no longer be listed on the top command.