### PR TITLE
Fix prune error on user id

### DIFF
--- a/src/main/java/de/chojo/repbot/commands/Prune.java
+++ b/src/main/java/de/chojo/repbot/commands/Prune.java
@@ -80,8 +80,9 @@ public class Prune extends SimpleCommand {
 
             user = event.getOption("userid");
             if (user != null) {
-                if (Verifier.isValidId(user.getAsString())) {
-                    gdprService.cleanupGuildUser(event.getGuild(), user.getAsUser().getIdLong());
+                var idRaw = Verifier.getIdRaw(user.getAsString());
+                if (idRaw.isPresent()) {
+                    gdprService.cleanupGuildUser(event.getGuild(), Long.valueOf(idRaw.get()));
                     event.reply(localizer.localize("command.prune.sub.user.removed")).queue();
                     return;
                 }


### PR DESCRIPTION
The bot tried to retrieve an user from a string, which is most probably a long or a long in id format.
Bot accepts now long and long in id format