### PR TITLE
Fix exception for wrong channel type

### DIFF
--- a/src/main/java/de/chojo/repbot/listener/ReactionListener.java
+++ b/src/main/java/de/chojo/repbot/listener/ReactionListener.java
@@ -88,7 +88,7 @@ public class ReactionListener extends ListenerAdapter {
             receiver = newReceiver.getUser();
         }
 
-        if (PermissionErrorHandler.assertAndHandle(event.getTextChannel(), localizer, configuration, Permission.MESSAGE_SEND)) {
+        if (PermissionErrorHandler.assertAndHandle(event.getGuildChannel(), localizer, configuration, Permission.MESSAGE_SEND)) {
             return;
         }
 


### PR DESCRIPTION
The verbose logger showed an exception for wrong channel types.

This was caused by events happening in a Thread Channel, while the code still tried to get a Text Channel from the event. \
The exception occurred quite frequently and is worth a fix :D

[Log Message (internal)](https://canary.discord.com/channels/853250161915985958/853262512668278814/938087834441646150)