### PR TITLE
Decouple permission apply for commands from welcome message

### DIFF
--- a/src/main/java/de/chojo/repbot/listener/StateListener.java
+++ b/src/main/java/de/chojo/repbot/listener/StateListener.java
@@ -53,11 +53,12 @@ public class StateListener extends ListenerAdapter {
 
         if (configuration.botlist().isBotlistGuild(event.getGuild().getIdLong())) return;
 
+        executorService.schedule(() -> Permissions.buildGuildPriviledges(guildData, event.getGuild()), 5, TimeUnit.SECONDS);
+
         var selfMember = event.getGuild().getSelfMember();
         for (var channel : event.getGuild().getTextChannels()) {
             if (selfMember.hasPermission(channel, Permission.VIEW_CHANNEL)
                 && selfMember.hasPermission(channel, Permission.MESSAGE_SEND)) {
-                executorService.schedule(() -> Permissions.buildGuildPriviledges(guildData, event.getGuild()), 5, TimeUnit.SECONDS);
                 channel.sendMessage(localizer.localize("message.welcome", event.getGuild())).queueAfter(5, TimeUnit.SECONDS);
                 break;
             }


### PR DESCRIPTION
There have been problems with verification gated guilds where you are not able to send messages to any channel on join. As result, the permissions for the commands have not been applied and no administrative commands are usable on these guilds.

[Example here](https://canary.discord.com/channels/853250161915985958/853252202524442685/941816347199938651) and [probably here](https://canary.discord.com/channels/853250161915985958/853252202524442685/944677093046911107)