### PR TITLE
Fix/some unhandled exceptions

### DIFF
--- a/src/main/java/de/chojo/repbot/listener/MessageListener.java
+++ b/src/main/java/de/chojo/repbot/listener/MessageListener.java
@@ -74,7 +74,6 @@ public class MessageListener extends ListenerAdapter {
 
     @Override
     public void onMessageDelete(@NotNull MessageDeleteEvent event) {
-        if(!event.isFromGuild()) return;
         reputationData.removeMessage(event.getMessageIdLong());
     }
 

--- a/src/main/java/de/chojo/repbot/listener/MessageListener.java
+++ b/src/main/java/de/chojo/repbot/listener/MessageListener.java
@@ -74,6 +74,7 @@ public class MessageListener extends ListenerAdapter {
 
     @Override
     public void onMessageDelete(@NotNull MessageDeleteEvent event) {
+        if(!event.isFromGuild()) return;
         reputationData.removeMessage(event.getMessageIdLong());
     }
 
@@ -84,13 +85,9 @@ public class MessageListener extends ListenerAdapter {
 
     @Override
     public void onMessageReceived(@NotNull MessageReceivedEvent event) {
-        if (event.getAuthor().isBot() || event.isWebhookMessage()) return;
+        if (event.getAuthor().isBot() || event.isWebhookMessage() || !event.isFromGuild()) return;
         var guild = event.getGuild();
         var settings = guildData.getGuildSettings(guild);
-
-        if (!event.isFromGuild()) {
-            return;
-        }
 
         if (event.getMessage().getType() != MessageType.DEFAULT && event.getMessage().getType() != MessageType.INLINE_REPLY) {
             return;

--- a/src/main/java/de/chojo/repbot/listener/ReactionListener.java
+++ b/src/main/java/de/chojo/repbot/listener/ReactionListener.java
@@ -18,8 +18,11 @@ import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.events.message.react.MessageReactionRemoveAllEvent;
 import net.dv8tion.jda.api.events.message.react.MessageReactionRemoveEmoteEvent;
 import net.dv8tion.jda.api.events.message.react.MessageReactionRemoveEvent;
+import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.requests.ErrorResponse;
+import net.dv8tion.jda.api.requests.RestAction;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
@@ -52,6 +55,7 @@ public class ReactionListener extends ListenerAdapter {
     @Override
     public void onMessageReactionAdd(@NotNull MessageReactionAddEvent event) {
         if (event.getUser().isBot()) return;
+        if(!event.isFromGuild()) return;
         var guildSettings = guildData.getGuildSettings(event.getGuild());
 
         if (!guildSettings.thankSettings().isReputationChannel(event.getChannel())) return;
@@ -109,6 +113,7 @@ public class ReactionListener extends ListenerAdapter {
 
     @Override
     public void onMessageReactionRemoveEmote(@NotNull MessageReactionRemoveEmoteEvent event) {
+        if(!event.isFromGuild()) return;
         var guildSettings = guildData.getGuildSettings(event.getGuild());
         if (!guildSettings.thankSettings().isReaction(event.getReactionEmote())) return;
         reputationData.removeMessage(event.getMessageIdLong());
@@ -116,17 +121,20 @@ public class ReactionListener extends ListenerAdapter {
 
     @Override
     public void onMessageReactionRemove(@NotNull MessageReactionRemoveEvent event) {
+        if(!event.isFromGuild()) return;
         var guildSettings = guildData.getGuildSettings(event.getGuild());
         if (!guildSettings.thankSettings().isReaction(event.getReactionEmote())) return;
         if (reputationData.removeReputation(event.getUserIdLong(), event.getMessageIdLong(), ThankType.REACTION)) {
             event.getChannel().sendMessage(localizer.localize("listener.reaction.removal", event.getGuild(),
                             Replacement.create("DONOR", User.fromId(event.getUserId()).getAsMention())))
-                    .delay(30, TimeUnit.SECONDS).flatMap(Message::delete).queue();
+                    .delay(30, TimeUnit.SECONDS).flatMap(Message::delete)
+                    .queue(RestAction.getDefaultSuccess(), ErrorResponseException.ignore(ErrorResponse.UNKNOWN_MESSAGE));
         }
     }
 
     @Override
     public void onMessageReactionRemoveAll(@NotNull MessageReactionRemoveAllEvent event) {
+        if(!event.isFromGuild()) return;
         reputationData.removeMessage(event.getMessageIdLong());
     }
 

--- a/src/main/java/de/chojo/repbot/listener/ReactionListener.java
+++ b/src/main/java/de/chojo/repbot/listener/ReactionListener.java
@@ -54,8 +54,7 @@ public class ReactionListener extends ListenerAdapter {
 
     @Override
     public void onMessageReactionAdd(@NotNull MessageReactionAddEvent event) {
-        if (event.getUser().isBot()) return;
-        if(!event.isFromGuild()) return;
+        if (event.getUser().isBot() || !event.isFromGuild()) return;
         var guildSettings = guildData.getGuildSettings(event.getGuild());
 
         if (!guildSettings.thankSettings().isReputationChannel(event.getChannel())) return;
@@ -113,7 +112,7 @@ public class ReactionListener extends ListenerAdapter {
 
     @Override
     public void onMessageReactionRemoveEmote(@NotNull MessageReactionRemoveEmoteEvent event) {
-        if(!event.isFromGuild()) return;
+        if (!event.isFromGuild()) return;
         var guildSettings = guildData.getGuildSettings(event.getGuild());
         if (!guildSettings.thankSettings().isReaction(event.getReactionEmote())) return;
         reputationData.removeMessage(event.getMessageIdLong());
@@ -121,7 +120,7 @@ public class ReactionListener extends ListenerAdapter {
 
     @Override
     public void onMessageReactionRemove(@NotNull MessageReactionRemoveEvent event) {
-        if(!event.isFromGuild()) return;
+        if (!event.isFromGuild()) return;
         var guildSettings = guildData.getGuildSettings(event.getGuild());
         if (!guildSettings.thankSettings().isReaction(event.getReactionEmote())) return;
         if (reputationData.removeReputation(event.getUserIdLong(), event.getMessageIdLong(), ThankType.REACTION)) {
@@ -134,7 +133,6 @@ public class ReactionListener extends ListenerAdapter {
 
     @Override
     public void onMessageReactionRemoveAll(@NotNull MessageReactionRemoveAllEvent event) {
-        if(!event.isFromGuild()) return;
         reputationData.removeMessage(event.getMessageIdLong());
     }
 

--- a/src/main/java/de/chojo/repbot/listener/voting/ReputationVoteListener.java
+++ b/src/main/java/de/chojo/repbot/listener/voting/ReputationVoteListener.java
@@ -23,6 +23,7 @@ import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 import net.dv8tion.jda.api.requests.ErrorResponse;
+import net.dv8tion.jda.api.requests.RestAction;
 import org.jetbrains.annotations.NotNull;
 
 import java.awt.Color;
@@ -60,12 +61,11 @@ public class ReputationVoteListener extends ListenerAdapter {
         var voteRequest = voteRequests.get(event.getMessageIdLong());
         if (!Verifier.equalSnowflake(voteRequest.member(), event.getMember())) {
             event.getHook().sendMessage(loc.localize("error.notYourEmbed", event.getGuild())).setEphemeral(true)
-                    .queue(message -> {
-                    }, throwable -> ErrorResponseException.ignore(ErrorResponse.UNKNOWN_MESSAGE));
+                    .queue(RestAction.getDefaultSuccess(), ErrorResponseException.ignore(ErrorResponse.UNKNOWN_MESSAGE));
             return;
         }
         if ("vote:delete".equals(event.getButton().getId())) {
-            event.getMessage().delete().queue();
+            event.getMessage().delete().queue(RestAction.getDefaultSuccess(), ErrorResponseException.ignore(ErrorResponse.UNKNOWN_MESSAGE));
             voteRequests.remove(event.getMessageIdLong());
             return;
         }

--- a/src/main/java/de/chojo/repbot/util/Messages.java
+++ b/src/main/java/de/chojo/repbot/util/Messages.java
@@ -3,6 +3,9 @@ package de.chojo.repbot.util;
 import de.chojo.repbot.data.wrapper.GuildSettings;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.exceptions.ErrorResponseException;
+import net.dv8tion.jda.api.requests.ErrorResponse;
+import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.internal.utils.PermissionUtil;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -34,7 +37,7 @@ public class Messages {
 
     public static void markMessage(Message message, String emoji) {
         if (PermissionUtil.checkPermission(message.getGuildChannel().getPermissionContainer(), message.getGuild().getSelfMember(), Permission.MESSAGE_ADD_REACTION)) {
-            message.addReaction(emoji).queue();
+            message.addReaction(emoji).queue(RestAction.getDefaultSuccess(), ErrorResponseException.ignore(ErrorResponse.UNKNOWN_MESSAGE));
         }
     }
 }


### PR DESCRIPTION
This ignores some ErrorResponseExceptions (ErrorResponse.UNKNOWN_MESSAGE) because they are not mission critical and can be considered expected in certain scenarios.

Also prevents some IllegalStateExceptions caused by missing checks, if the event happened in a Guild.