### PR TITLE
Fix Docker Compose Setup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ RUN rm -r \
         *.jar
 
 FROM adoptopenjdk/openjdk16:alpine-jre
-WORKDIR /application
+WORKDIR /
 ENV TERM xterm-256color
 # Copy all dependencies
 COPY --from=extractDependencies extractDependencies/ ./
@@ -55,4 +55,4 @@ COPY --from=unzip source/de/chojo/repbot de/chojo/repbot
 # Add start script
 ADD docker/start.sh start.sh
 RUN chmod +x start.sh
-ENTRYPOINT ["./start.sh"]
+ENTRYPOINT ["sh", "start.sh"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,11 +8,13 @@ services:
     depends_on:
       - database
     volumes:
-      - ${PWD}/config/:/config/
+      - ./config/:/config/
   database:
     networks:
       - repbot
     image: postgres:13.2
+    expose:
+      - "5432"
     volumes:
     - db_data:/var/lib/postgres/data
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - repbot
     image: postgres:13.2
     expose:
-      - "5432"
+      - 5432
     volumes:
     - db_data:/var/lib/postgres/data
     environment:


### PR DESCRIPTION
Relates to #210

This is the first part of making the Docker setup usable again. 
This fixes the configuration problem and making it available for windows by using `sh` directly in the Dockerfile instead of the implicit shebang.