### PR TITLE
Change docker images to use the same Java version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,13 +13,13 @@ RUN ./gradlew clean build --no-daemon > /dev/null 2>&1 || true
 COPY src/ src/
 RUN ./gradlew shadowJar --no-daemon
 
-FROM openjdk:15-jdk-alpine AS unzip
+FROM eclipse-temurin:17-jdk-alpine AS unzip
 WORKDIR /source
 COPY --from=build source/build/libs/rep-bot-*-all.jar app.jar
 # Extract jar
 RUN jar -xf app.jar
 
-FROM openjdk:15-alpine AS extractDependencies
+FROM eclipse-temurin:17-jre-alpine AS extractDependencies
 WORKDIR /extractDependencies
 # Copy everything from unzip stage
 COPY --from=unzip source/ ./
@@ -35,7 +35,7 @@ RUN rm -r \
         de/chojo/repbot \
         *.jar
 
-FROM adoptopenjdk/openjdk16:alpine-jre
+FROM eclipse-temurin:17-jre-alpine
 WORKDIR /application
 ENV TERM xterm-256color
 # Copy all dependencies


### PR DESCRIPTION
Relates to #210 

This is the second part of improving the Docker setup.
This makes sure, that all stages use the same java distribution and version

eclipse-temurin has been choosen as the gradle image is based on it.