### PR TITLE
Allows the entrypoint to be overridden at container start

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,4 +55,4 @@ COPY --from=unzip source/de/chojo/repbot de/chojo/repbot
 # Add start script
 ADD docker/start.sh start.sh
 RUN chmod +x start.sh
-ENTRYPOINT ["./start.sh"]
+CMD ["./start.sh"]


### PR DESCRIPTION
Relates to #210 

This is the third part of improving the Docker setup.
This allows to override the entrypoint of the image if wanted