### PR TITLE
Implement empty page handling

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 
 dependencies {
     //discord
-    implementation("de.chojo", "cjda-util", "2.3.1+alpha.9"){
+    implementation("de.chojo", "cjda-util", "2.3.3+alpha.9"){
         exclude(group = "club.minnced", module = "opus-java")
     }
 

--- a/src/main/java/de/chojo/repbot/commands/Log.java
+++ b/src/main/java/de/chojo/repbot/commands/Log.java
@@ -103,6 +103,12 @@ public class Log extends SimpleCommand {
                 return CompletableFuture.supplyAsync(() -> userLogEmbed(context, user, "command.log.donatedLog",
                         mapUserLogEntry(context, logAccess.page(current()), ReputationLogEntry::receiverId)));
             }
+
+            @Override
+            public CompletableFuture<MessageEmbed> buildEmptyPage() {
+                return CompletableFuture.completedFuture(userLogEmbed(context, user, "command.log.donatedLog",
+                        mapUserLogEntry(context, Collections.emptyList(), ReputationLogEntry::receiverId)));
+            }
         }, true);
     }
 
@@ -113,6 +119,12 @@ public class Log extends SimpleCommand {
             public CompletableFuture<MessageEmbed> buildPage() {
                 return CompletableFuture.supplyAsync(() -> userLogEmbed(context, user, "command.log.receivedLog",
                         mapUserLogEntry(context, logAccess.page(current()), ReputationLogEntry::donorId)));
+            }
+
+            @Override
+            public CompletableFuture<MessageEmbed> buildEmptyPage() {
+                return CompletableFuture.completedFuture(userLogEmbed(context, user, "command.log.receivedLog",
+                        mapUserLogEntry(context, Collections.emptyList(), ReputationLogEntry::donorId)));
             }
         }, true);
     }

--- a/src/main/java/de/chojo/repbot/commands/Top.java
+++ b/src/main/java/de/chojo/repbot/commands/Top.java
@@ -42,12 +42,6 @@ public class Top extends SimpleCommand {
                 return CompletableFuture.supplyAsync(() -> {
                     var ranking = guildRanking.page(current());
 
-                    if (ranking.isEmpty()) {
-                        return createBaseBuilder(context, event.getGuild())
-                                .setDescription("*" + context.localize("command.top.empty") + "*")
-                                .build();
-                    }
-
                     var maxRank = ranking.get(ranking.size() - 1).rank();
                     var rankString = ranking.stream().map(rank -> rank.fancyString((int) maxRank)).collect(Collectors.joining("\n"));
 
@@ -55,6 +49,13 @@ public class Top extends SimpleCommand {
                             .setDescription(rankString)
                             .build();
                 });
+            }
+
+            @Override
+            public CompletableFuture<MessageEmbed> buildEmptyPage() {
+                return CompletableFuture.completedFuture(createBaseBuilder(context, event.getGuild())
+                        .setDescription("*" + context.localize("command.top.empty") + "*")
+                        .build());
             }
         }, true);
     }


### PR DESCRIPTION
This handles empty pages now in a correct way without throwing an error.

Handling of empty pages is now done by cjda.
The buildEmptyPage method will be called when the page count is 0