### PR TITLE
Fix exception in emoji usability check

### DIFF
--- a/src/main/java/de/chojo/repbot/commands/Reactions.java
+++ b/src/main/java/de/chojo/repbot/commands/Reactions.java
@@ -18,7 +18,6 @@ import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.interactions.InteractionHook;
 
 import javax.sql.DataSource;
-import java.util.Set;
 import java.util.regex.Pattern;
 
 public class Reactions extends SimpleCommand {
@@ -160,7 +159,11 @@ public class Reactions extends SimpleCommand {
         if (emoteById == null) {
             return new EmojiCheckResult("", "", CheckResult.NOT_FOUND);
         }
-        message.addReaction(emoteById).queue();
+        try {
+            message.addReaction(emoteById).queue();
+        } catch (IllegalArgumentException e) {
+            return new EmojiCheckResult(null, "", CheckResult.NOT_FOUND);
+        }
         return new EmojiCheckResult(emoteById.getAsMention(), emoteById.getId(), CheckResult.EMOTE_FOUND);
     }
 


### PR DESCRIPTION
It looks like there is a case where `Guild#retrieveEmoteById` returns an emote which is not usable in the context of the channel.

I don't know if we should treat it like `NOT_FOUND` or if this should be its own status in CheckResult.

[Exceptions in Log (internal)](https://canary.discord.com/channels/853250161915985958/853262532261576724/971117072291606538)