### PR TITLE
Fix/role update

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "de.chojo"
-version = "1.6.8"
+version = "1.6.9"
 
 repositories {
     maven("https://eldonexus.de/repository/maven-public")

--- a/src/main/java/de/chojo/repbot/ReputationBot.java
+++ b/src/main/java/de/chojo/repbot/ReputationBot.java
@@ -291,7 +291,7 @@ public class ReputationBot {
     }
 
     private void initJDA() throws LoginException {
-        roleAssigner = new RoleAssigner(dataSource, repBotWorker);
+        roleAssigner = new RoleAssigner(dataSource);
         scan = new Scan(dataSource, configuration);
         roles = new Roles(dataSource, roleAssigner);
         repBotCachePolicy = new RepBotCachePolicy(scan, roles);

--- a/src/main/java/de/chojo/repbot/commands/Roles.java
+++ b/src/main/java/de/chojo/repbot/commands/Roles.java
@@ -10,11 +10,13 @@ import de.chojo.jdautil.wrapper.SlashCommandContext;
 import de.chojo.repbot.data.GuildData;
 import de.chojo.repbot.service.RoleAccessException;
 import de.chojo.repbot.service.RoleAssigner;
+import de.chojo.repbot.util.Guilds;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.IMentionable;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.exceptions.HierarchyException;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.slf4j.Logger;
 
@@ -113,7 +115,7 @@ public class Roles extends SimpleCommand {
                 .updateBatch(event.getGuild())
                 .onSuccess(res -> {
                     var duration = DurationFormatUtils.formatDuration(start.until(Instant.now(), ChronoUnit.MILLIS), "mm:ss");
-                    log.debug("Update of roles took: {}.", duration);
+                    log.info("Update of roles on {} took {}.", Guilds.prettyName(event.getGuild()), duration);
                     if (event.getHook().isExpired()) {
                         log.debug("Interaction hook is expired. Using fallback message.");
                         event.getChannel()
@@ -126,6 +128,7 @@ public class Roles extends SimpleCommand {
                             .queue();
                     running.remove(event.getGuild().getIdLong());
                 }).onError(err -> {
+                    log.warn("Update of role failed on guild {}", Guilds.prettyName(event.getGuild()), err);
                     if (err instanceof RoleAccessException roleException) {
                         event.getHook()
                                 .editOriginal(context.localize("error.roleAccess",

--- a/src/main/java/de/chojo/repbot/service/RepBotCachePolicy.java
+++ b/src/main/java/de/chojo/repbot/service/RepBotCachePolicy.java
@@ -1,5 +1,6 @@
 package de.chojo.repbot.service;
 
+import de.chojo.repbot.commands.Roles;
 import de.chojo.repbot.commands.Scan;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.utils.MemberCachePolicy;
@@ -16,8 +17,11 @@ public class RepBotCachePolicy implements MemberCachePolicy, Runnable {
     private final HashMap<Long, Instant> seen = new HashMap<>();
     private final Scan scan;
 
-    public RepBotCachePolicy(Scan scan) {
+    private final Roles roles;
+
+    public RepBotCachePolicy(Scan scan, Roles roles) {
         this.scan = scan;
+        this.roles = roles;
     }
 
     public void seen(Member member) {
@@ -39,6 +43,10 @@ public class RepBotCachePolicy implements MemberCachePolicy, Runnable {
         }
 
         if (scan.isRunning(member.getGuild())) {
+            return true;
+        }
+
+        if (roles.refreshActive(member.getGuild())) {
             return true;
         }
 

--- a/src/main/java/de/chojo/repbot/service/RoleAssigner.java
+++ b/src/main/java/de/chojo/repbot/service/RoleAssigner.java
@@ -4,33 +4,37 @@ import de.chojo.repbot.data.GuildData;
 import de.chojo.repbot.data.ReputationData;
 import de.chojo.repbot.data.wrapper.ReputationRole;
 import de.chojo.repbot.data.wrapper.ReputationUser;
+import de.chojo.repbot.util.Guilds;
+import de.chojo.repbot.util.Roles;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.exceptions.HierarchyException;
 import net.dv8tion.jda.api.utils.concurrent.Task;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
 
 import javax.sql.DataSource;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 public class RoleAssigner {
+    private static final Logger log = getLogger(RoleAssigner.class);
     private final GuildData guildData;
     private final ReputationData reputationData;
-    private final ExecutorService worker;
 
-    public RoleAssigner(DataSource dataSource, ExecutorService worker) {
+    public RoleAssigner(DataSource dataSource) {
         guildData = new GuildData(dataSource);
         reputationData = new ReputationData(dataSource);
-        this.worker = worker;
     }
 
-    public void update(@Nullable Member member) throws HierarchyException, RoleAccessException {
+    public void update(@Nullable Member member) throws RoleAccessException {
         if (member == null) return;
+        log.debug("Updating {} on {}", member.getId(), Guilds.prettyName(member.getGuild()));
         var guild = member.getGuild();
         var reputation = reputationData.getReputation(guild, member.getUser()).orElse(ReputationUser.empty(member.getUser()));
         var settings = guildData.getGuildSettings(member.getGuild());
@@ -43,12 +47,14 @@ public class RoleAssigner {
 
         cleanMemberRoles(member, roles);
 
-        if (member.getRoles().containsAll(roles)) return;
+        if (new HashSet<>(member.getRoles()).containsAll(roles)) return;
 
         for (var role : roles) {
             assertInteract(role, member.getGuild());
-            if (!member.getRoles().contains(role))
+            if (!member.getRoles().contains(role)) {
+                log.debug("Assigning role {} on {}", Roles.prettyName(role), Guilds.prettyName(guild));
                 guild.addRoleToMember(member, role).complete();
+            }
         }
     }
 
@@ -62,6 +68,7 @@ public class RoleAssigner {
         for (var role : reputationRoles) {
             assertInteract(role, member.getGuild());
             if (roles.contains(role)) continue;
+            log.debug("Removing role {} on {}", Roles.prettyName(role), Guilds.prettyName(guild));
             guild.removeRoleFromMember(member, role).complete();
         }
     }
@@ -73,6 +80,7 @@ public class RoleAssigner {
     }
 
     public Task<Void> updateBatch(Guild guild) {
+        log.info("Started batch update for guild {}", Guilds.prettyName(guild));
         return guild.loadMembers(this::update);
     }
 }

--- a/src/main/java/de/chojo/repbot/service/RoleAssigner.java
+++ b/src/main/java/de/chojo/repbot/service/RoleAssigner.java
@@ -8,6 +8,7 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.exceptions.HierarchyException;
+import net.dv8tion.jda.api.utils.concurrent.Task;
 import org.jetbrains.annotations.Nullable;
 
 import javax.sql.DataSource;
@@ -57,8 +58,7 @@ public class RoleAssigner {
                 .stream()
                 .map(ReputationRole::roleId)
                 .map(guild::getRoleById)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .filter(Objects::nonNull).toList();
         for (var role : reputationRoles) {
             assertInteract(role, member.getGuild());
             if (roles.contains(role)) continue;
@@ -72,11 +72,7 @@ public class RoleAssigner {
         }
     }
 
-    public CompletableFuture<Void> updateBatch(Guild guild) {
-        return CompletableFuture.runAsync(() -> {
-            for (var member : guild.loadMembers().get()) {
-                update(member);
-            }
-        }, worker);
+    public Task<Void> updateBatch(Guild guild) {
+        return guild.loadMembers(this::update);
     }
 }

--- a/src/main/java/de/chojo/repbot/util/Roles.java
+++ b/src/main/java/de/chojo/repbot/util/Roles.java
@@ -1,0 +1,13 @@
+package de.chojo.repbot.util;
+
+import net.dv8tion.jda.api.entities.Role;
+
+public final class Roles {
+    private Roles() {
+        throw new UnsupportedOperationException("This is a utility class.");
+    }
+
+    public static String prettyName(Role role) {
+        return String.format("%s (%s)", role.getName(), role.getIdLong());
+    }
+}


### PR DESCRIPTION
Enhance the role update.

- Keep members in cache during update
- Add logging for insights
- Use consumer instead of polling all users at once.