### PR TITLE
Escape exception when max reaction are reached

### DIFF
--- a/src/main/java/de/chojo/repbot/util/Messages.java
+++ b/src/main/java/de/chojo/repbot/util/Messages.java
@@ -41,7 +41,7 @@ public final class Messages {
 
     public static void markMessage(Message message, String emoji) {
         if (PermissionUtil.checkPermission(message.getGuildChannel().getPermissionContainer(), message.getGuild().getSelfMember(), Permission.MESSAGE_ADD_REACTION)) {
-            message.addReaction(emoji).queue(RestAction.getDefaultSuccess(), ErrorResponseException.ignore(ErrorResponse.UNKNOWN_MESSAGE));
+            message.addReaction(emoji).queue(RestAction.getDefaultSuccess(), ErrorResponseException.ignore(ErrorResponse.UNKNOWN_MESSAGE, ErrorResponse.TOO_MANY_REACTIONS));
         }
     }
 }

--- a/src/main/java/de/chojo/repbot/util/Messages.java
+++ b/src/main/java/de/chojo/repbot/util/Messages.java
@@ -2,6 +2,7 @@ package de.chojo.repbot.util;
 
 import de.chojo.repbot.dao.access.guild.settings.Settings;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.ListedEmote;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.requests.ErrorResponse;
@@ -20,28 +21,32 @@ public final class Messages {
     }
 
     public static void markMessage(Message message, @Nullable Message refMessage, Settings settings) {
+        var reaction = settings.thanking().reactions().mainReaction();
         if (settings.thanking().reactions().reactionIsEmote()) {
-            message.getGuild().retrieveEmoteById(settings.thanking().reactions().mainReaction()).queue(e -> {
-                message.addReaction(e).queue(emote -> {
-                }, err -> log.error("Could not add reaction emote", err));
-                if (refMessage != null) {
-                    refMessage.addReaction(e).queue(emote -> {
-                    }, err -> log.error("Could not add reaction emote", err));
-                }
+            message.getGuild().retrieveEmoteById(reaction).queue(e -> {
+                markMessage(message, e);
+                if (refMessage != null) markMessage(refMessage, e);
             }, err -> log.error("Could not resolve emoji.", err));
         } else {
-            if (refMessage != null) {
-                message.addReaction(settings.thanking().reactions().mainReaction()).queue(e -> {
-                }, err -> log.error("Could not add reaction emoji.", err));
-            }
-            message.addReaction(settings.thanking().reactions().mainReaction()).queue(e -> {
-            }, err -> log.error("Could not add reaction emoji.", err));
+            if (refMessage != null) markMessage(refMessage, reaction);
+            markMessage(message, reaction);
+        }
+    }
+
+    public static void markMessage(Message message, ListedEmote emote) {
+        if (PermissionUtil.checkPermission(message.getGuildChannel().getPermissionContainer(), message.getGuild().getSelfMember(), Permission.MESSAGE_ADD_REACTION)) {
+            handleMark(message.addReaction(emote));
         }
     }
 
     public static void markMessage(Message message, String emoji) {
         if (PermissionUtil.checkPermission(message.getGuildChannel().getPermissionContainer(), message.getGuild().getSelfMember(), Permission.MESSAGE_ADD_REACTION)) {
-            message.addReaction(emoji).queue(RestAction.getDefaultSuccess(), ErrorResponseException.ignore(ErrorResponse.UNKNOWN_MESSAGE, ErrorResponse.TOO_MANY_REACTIONS));
+            handleMark(message.addReaction(emoji));
         }
+    }
+
+    private static void handleMark(RestAction<Void> action) {
+        action.queue(RestAction.getDefaultSuccess(),
+                ErrorResponseException.ignore(ErrorResponse.UNKNOWN_MESSAGE, ErrorResponse.TOO_MANY_REACTIONS));
     }
 }


### PR DESCRIPTION
Fixes an exception when a message has already 20 emotes added and the bot tries to add another one.
I have also made a small refactoring to remove duplicated code and duplicated error handling