### PR TITLE
Fix non matching thankwords cause by casing #306

### DIFF
--- a/src/main/java/de/chojo/repbot/analyzer/MessageAnalyzer.java
+++ b/src/main/java/de/chojo/repbot/analyzer/MessageAnalyzer.java
@@ -64,7 +64,7 @@ public class MessageAnalyzer {
     private AnalyzerResult analyze(Pattern pattern, Message message, @Nullable Settings settings, boolean limitTargets, int limit) {
         metrics.messages().countMessage();
         if (pattern.pattern().isBlank()) return AnalyzerResult.noMatch();
-        var contentRaw = message.getContentRaw();
+        var contentRaw = message.getContentRaw().toLowerCase();
 
         if (!pattern.matcher(contentRaw).find()) return AnalyzerResult.noMatch();
         if (message.getType() == MessageType.INLINE_REPLY) {


### PR DESCRIPTION
For now it seems to be enough when simply parsing the message to a lower case message. I dont know how well this will work with all languages in general, but for now I think this will solve a lot of potential issues.

Closes #306 