### PR TITLE
Fix scientific number notation on large numbers

### DIFF
--- a/src/main/java/de/chojo/repbot/dao/snapshots/statistics/CountsStatistic.java
+++ b/src/main/java/de/chojo/repbot/dao/snapshots/statistics/CountsStatistic.java
@@ -36,6 +36,7 @@ public record CountsStatistic(List<CountStatistics> stats) implements ChartProvi
         styler.setXAxisLabelRotation(20);
         styler.setXAxisLabelAlignmentVertical(AxesChartStyler.TextAlignment.Right);
         styler.setXAxisLabelAlignment(AxesChartStyler.TextAlignment.Right);
+        styler.setYAxisDecimalPattern("##,###");
 
         var sorted = stats.stream().sorted().toList();
 


### PR DESCRIPTION
Replace the scientific notation on large numbers with a better readable format.

Before:
![image](https://user-images.githubusercontent.com/46890129/179750874-ec23cc4a-f774-4ea7-9b49-780601fff2e0.png)

After:
![image](https://user-images.githubusercontent.com/46890129/179750825-ec1498c0-fb9b-438f-bf40-a55573eacc2f.png)
