### PR TITLE
Fix role not assigned when a role was removed previously

### DIFF
--- a/src/main/java/de/chojo/repbot/service/RoleAssigner.java
+++ b/src/main/java/de/chojo/repbot/service/RoleAssigner.java
@@ -48,9 +48,10 @@ public class RoleAssigner {
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
 
-        var changed = cleanMemberRoles(member, roles);
+        var removed = cleanMemberRoles(member, roles);
+        var added = addMemberRoles(member, roles);
 
-        changed = changed || addMemberRoles(member, roles);
+        var changed = removed || added;
 
         if (!changed) {
             return Optional.empty();


### PR DESCRIPTION
The add method was not executed when a role was removed because the boolean expression was evaluated with true already in this case.

This caused that a role was not given when a role was taken, which affects every level up except the first one.