### PR TITLE
Fix title localization for RepProfile

### DIFF
--- a/src/main/java/de/chojo/repbot/dao/snapshots/RepProfile.java
+++ b/src/main/java/de/chojo/repbot/dao/snapshots/RepProfile.java
@@ -91,7 +91,7 @@ public record RepProfile(RepUser repUser, long rank, long rankDonated, long user
         var currProgress = String.valueOf(reputation() - currentRoleRep);
         var nextLevel = nextRoleRep.equals(currentRoleRep) ? "Ꝏ" : String.valueOf(nextRoleRep - currentRoleRep);
         var build = new LocalizedEmbedBuilder(localizer)
-                .setAuthor("%s%s".formatted(rank() != 0 ? "#" + rank() + " " : "", "element.profile.title"),
+                .setAuthor("%s$%s$".formatted(rank() != 0 ? "#" + rank() + " " : "", "element.profile.title"),
                         null, repUser.member().getEffectiveAvatarUrl(),
                         Replacement.create("NAME", repUser.member().getEffectiveName()))
                 .addField("words.level", level, true)


### PR DESCRIPTION
Currently the localization for the embed title of the RepProfile does not work
![image](https://user-images.githubusercontent.com/39954661/192119823-5d2ab383-6b19-49fc-89a3-e41f5fa165ed.png)

I think this is caused by the rank being added in front of the message key