### PR TITLE
Fix NPEs in scan cased by old members not present in cache

### DIFF
--- a/src/main/java/de/chojo/repbot/analyzer/MessageAnalyzer.java
+++ b/src/main/java/de/chojo/repbot/analyzer/MessageAnalyzer.java
@@ -117,7 +117,14 @@ public class MessageAnalyzer {
 
             if (members.isEmpty()) return Result.empty(match, EmptyResultReason.TARGET_NOT_ON_GUILD);
 
-            return Result.mention(match, message.getMember(), members);
+            Member author;
+            try {
+                author = message.getGuild().retrieveMember(message.getAuthor()).complete();
+            } catch (RuntimeException e) {
+                return Result.empty(EmptyResultReason.TARGET_NOT_ON_GUILD);
+            }
+
+            return Result.mention(match, author, members);
         }
         return resolveMessage(match, message, pattern, context, limitTargets, limit);
     }
@@ -181,6 +188,13 @@ public class MessageAnalyzer {
 
         var thankwords = thankWordIndices.stream().map(words::get).collect(Collectors.toList());
 
-        return Result.fuzzy(matchPattern, thankwords, memberMatches, message.getMember(), members);
+        Member author;
+        try {
+            author = message.getGuild().retrieveMember(message.getAuthor()).complete();
+        } catch (RuntimeException e) {
+            return Result.empty(EmptyResultReason.TARGET_NOT_ON_GUILD);
+        }
+
+        return Result.fuzzy(matchPattern, thankwords, memberMatches, author, members);
     }
 }


### PR DESCRIPTION
**Checklist**
- [ ] I made changes to commands
  - [ ] I fully localised the command
  - [ ] I fully checked the commands functionality

- [ ] I added new localisation codes
  - [ ] I fully translated it for all languages
  - [ ] I sorted properties alphabetically


- [ ] I made changes to the database
  - [ ] I added my changed to a patch file
  - [ ] I made sure my database was up to date
  - [ ] I checked that the migration works

- [x] I made changes to internal structure 


**Short Description**
There is a good chance that a message author is not part of the guild anymore during a scan. This avoids any NPEs caused by this.

**Detailed Description**
<!-- Add additional information to your pull request -->


<!-- Add your issue number here or delete this part if this PR is not related to an issue -->
  
