### PR TITLE
Fix user metrics not saved

### DIFF
--- a/src/main/java/de/chojo/repbot/dao/access/metrics/Users.java
+++ b/src/main/java/de/chojo/repbot/dao/access/metrics/Users.java
@@ -66,7 +66,7 @@ public class Users extends QueryFactory {
                        INSERT INTO metrics_users_month
                        SELECT month, receiver_count, donor_count, total_count
                        FROM metrics_unique_users_month
-                       WHERE month = DATE_TRUNC('week', NOW()  - INTERVAL '1 WEEK')
+                       WHERE month = DATE_TRUNC('month', NOW()  - INTERVAL '1 MONTH')
                        ON CONFLICT(month) 
                            DO UPDATE SET receiver_count = excluded.receiver_count,
                                donor_count = excluded.donor_count,


### PR DESCRIPTION
**Checklist**
- [ ] I made changes to commands
  - [ ] I fully localised the command
  - [ ] I fully checked the commands functionality

- [ ] I added new localisation codes
  - [ ] I fully translated it for all languages
  - [ ] I sorted properties alphabetically


- [ ] I made changes to the database
  - [ ] I added my changed to a patch file
  - [ ] I made sure my database was up to date
  - [ ] I checked that the migration works

- [x] I made changes to internal structure 


**Short Description**
For some reason the date was truncated on a week instead of a month. this caused stats not being saved unless the 1. day of a month was a monday.
  
