### PR TITLE
Fix npe caused by missing member in message received 🤔

### DIFF
--- a/src/main/java/de/chojo/repbot/service/RoleUpdater.java
+++ b/src/main/java/de/chojo/repbot/service/RoleUpdater.java
@@ -34,7 +34,7 @@ public class RoleUpdater extends ListenerAdapter implements Runnable {
     public void onMessageReceived(@NotNull MessageReceivedEvent event) {
         if (!event.isFromGuild()) return;
         if (!guilds.guild(event.getGuild()).settings().general().reputationMode().isAutoRefresh()) return;
-        if (isChecked(event.getMember())) return;
+        if (event.getMember() == null || isChecked(event.getMember())) return;
         roleAssigner.updateReporting(event.getMember(), event.getGuildChannel());
         guildSet(event.getGuild()).add(event.getMember().getIdLong());
     }


### PR DESCRIPTION
**Checklist**
- [ ] I made changes to commands
  - [ ] I fully localised the command
  - [ ] I fully checked the commands functionality

- [ ] I added new localisation codes
  - [ ] I fully translated it for all languages
  - [ ] I sorted properties alphabetically


- [ ] I made changes to the database
  - [ ] I added my changed to a patch file
  - [ ] I made sure my database was up to date
  - [ ] I checked that the migration works

- [x] I made changes to internal structure 


**Short Description**
For some reason the member can be null in a guild message received event 🤔



  
