### PR TITLE
Remove additional emojis on deletion

### DIFF
--- a/src/main/java/de/chojo/repbot/listener/StateListener.java
+++ b/src/main/java/de/chojo/repbot/listener/StateListener.java
@@ -94,6 +94,9 @@ public class StateListener extends ListenerAdapter {
     public void onEmojiRemoved(@NotNull EmojiRemovedEvent event) {
         var guildSettings = guilds.guild(event.getGuild()).settings();
         if (!guildSettings.thanking().reactions().reactionIsEmote()) return;
+
+        guildSettings.thanking().reactions().remove(event.getEmoji().getId());
+
         if (!guildSettings.thanking().reactions().mainReaction().equals(event.getEmoji().getId())) return;
         guildSettings.thanking().reactions().mainReaction("🏅");
     }

--- a/src/main/java/de/chojo/repbot/listener/StateListener.java
+++ b/src/main/java/de/chojo/repbot/listener/StateListener.java
@@ -93,10 +93,9 @@ public class StateListener extends ListenerAdapter {
     @Override
     public void onEmojiRemoved(@NotNull EmojiRemovedEvent event) {
         var guildSettings = guilds.guild(event.getGuild()).settings();
-        if (!guildSettings.thanking().reactions().reactionIsEmote()) return;
-
         guildSettings.thanking().reactions().remove(event.getEmoji().getId());
 
+        if (!guildSettings.thanking().reactions().reactionIsEmote()) return;
         if (!guildSettings.thanking().reactions().mainReaction().equals(event.getEmoji().getId())) return;
         guildSettings.thanking().reactions().mainReaction("🏅");
     }


### PR DESCRIPTION
**Checklist**
- [ ] I made changes to commands
  - [ ] I fully localised the command
  - [ ] I fully checked the commands functionality

- [ ] I added new localisation codes
  - [ ] I fully translated it for all languages
  - [ ] I sorted properties alphabetically


- [ ] I made changes to the database
  - [ ] I added my changed to a patch file
  - [ ] I made sure my database was up to date
  - [ ] I checked that the migration works

- [x] I made changes to internal structure 


**Short Description**
Deleting an emoji only resets the main reaction if the deleted emoji was the main reaction. It now also removes additional emojis.


  
