### PR TITLE
Release 1.13.5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "de.chojo"
-version = "1.13.4"
+version = "1.13.5"
 
 repositories {
     maven("https://eldonexus.de/repository/maven-public")

--- a/src/main/java/de/chojo/repbot/dao/access/guild/settings/sub/thanking/Reactions.java
+++ b/src/main/java/de/chojo/repbot/dao/access/guild/settings/sub/thanking/Reactions.java
@@ -62,7 +62,7 @@ public class Reactions extends QueryFactory implements GuildHolder {
         if (!reactionIsEmote()) {
             return Optional.ofNullable(mainReaction());
         }
-        return Optional.of(guild().retrieveEmojiById(mainReaction()).onErrorFlatMap(err -> null).complete())
+        return Optional.of(guild().retrieveEmojiById(mainReaction()).onErrorMap(err -> null).complete())
                 .map(CustomEmoji::getAsMention);
     }
 
@@ -74,7 +74,7 @@ public class Reactions extends QueryFactory implements GuildHolder {
         return reactions.stream()
                         .map(reaction -> {
                             if (Verifier.isValidId(reaction)) {
-                                var asMention = guild().retrieveEmojiById(reaction).onErrorFlatMap(err -> null)
+                                var asMention = guild().retrieveEmojiById(reaction).onErrorMap(err -> null)
                                                        .complete();
                                 return asMention == null ? null : asMention.getAsMention();
                             }

--- a/src/main/java/de/chojo/repbot/listener/StateListener.java
+++ b/src/main/java/de/chojo/repbot/listener/StateListener.java
@@ -93,6 +93,8 @@ public class StateListener extends ListenerAdapter {
     @Override
     public void onEmojiRemoved(@NotNull EmojiRemovedEvent event) {
         var guildSettings = guilds.guild(event.getGuild()).settings();
+        guildSettings.thanking().reactions().remove(event.getEmoji().getId());
+
         if (!guildSettings.thanking().reactions().reactionIsEmote()) return;
         if (!guildSettings.thanking().reactions().mainReaction().equals(event.getEmoji().getId())) return;
         guildSettings.thanking().reactions().mainReaction("🏅");


### PR DESCRIPTION
*Fix for deleted additional reactions*
While deleting an additional reaction on the server doesn't break the general usage of reaction is breaks the embed showing the currently active reactions.
We added a check to directly remove those dead entries from our database and will also simply ignore them when we build the info embed.
