### PR TITLE
Fix usage of setAllowedMentions and mention

### DIFF
--- a/src/main/java/de/chojo/repbot/commands/roles/handler/List.java
+++ b/src/main/java/de/chojo/repbot/commands/roles/handler/List.java
@@ -22,7 +22,7 @@ public class List implements SlashHandler {
 
     @Override
     public void onSlashCommand(SlashCommandInteractionEvent event, EventContext context) {
-        event.replyEmbeds(getRoleList(context, event.getGuild())).mention(Collections.emptyList()).queue();
+        event.replyEmbeds(getRoleList(context, event.getGuild())).setAllowedMentions(Collections.emptyList()).queue();
     }
 
     private MessageEmbed getRoleList(EventContext context, Guild guild) {

--- a/src/main/java/de/chojo/repbot/commands/roles/handler/donor/AddDonor.java
+++ b/src/main/java/de/chojo/repbot/commands/roles/handler/donor/AddDonor.java
@@ -20,6 +20,6 @@ public class AddDonor implements SlashHandler {
         var role = event.getOption("role").getAsRole();
         guilds.guild(event.getGuild()).settings().thanking().donorRoles().add(role);
         event.reply(context.localize("command.roles.donor.add.message.add",
-                Replacement.createMention(role))).mention(Collections.emptyList()).queue();
+                Replacement.createMention(role))).setAllowedMentions(Collections.emptyList()).queue();
     }
 }

--- a/src/main/java/de/chojo/repbot/commands/roles/handler/donor/RemoveDonor.java
+++ b/src/main/java/de/chojo/repbot/commands/roles/handler/donor/RemoveDonor.java
@@ -20,6 +20,6 @@ public class RemoveDonor implements SlashHandler {
         var role = event.getOption("role").getAsRole();
         guilds.guild(event.getGuild()).settings().thanking().donorRoles().remove(role);
         event.reply(context.localize("command.roles.donor.remove.message.remove",
-                Replacement.createMention(role))).mention(Collections.emptyList()).queue();
+                Replacement.createMention(role))).setAllowedMentions(Collections.emptyList()).queue();
     }
 }

--- a/src/main/java/de/chojo/repbot/commands/roles/handler/receiver/AddReceiver.java
+++ b/src/main/java/de/chojo/repbot/commands/roles/handler/receiver/AddReceiver.java
@@ -20,6 +20,6 @@ public class AddReceiver implements SlashHandler {
         var role = event.getOption("role").getAsRole();
         guilds.guild(event.getGuild()).settings().thanking().receiverRoles().add(role);
         event.reply(context.localize("command.roles.receiver.add.message.add",
-                Replacement.createMention(role))).mention(Collections.emptyList()).queue();
+                Replacement.createMention(role))).setAllowedMentions(Collections.emptyList()).queue();
     }
 }

--- a/src/main/java/de/chojo/repbot/commands/roles/handler/receiver/RemoveReceiver.java
+++ b/src/main/java/de/chojo/repbot/commands/roles/handler/receiver/RemoveReceiver.java
@@ -20,6 +20,6 @@ public class RemoveReceiver implements SlashHandler {
         var role = event.getOption("role").getAsRole();
         guilds.guild(event.getGuild()).settings().thanking().receiverRoles().remove(role);
         event.reply(context.localize("command.roles.receiver.remove.message.remove",
-                Replacement.createMention(role))).mention(Collections.emptyList()).queue();
+                Replacement.createMention(role))).setAllowedMentions(Collections.emptyList()).queue();
     }
 }

--- a/src/main/java/de/chojo/repbot/commands/setup/handler/Start.java
+++ b/src/main/java/de/chojo/repbot/commands/setup/handler/Start.java
@@ -167,7 +167,7 @@ public class Start implements SlashHandler {
         context.reply(
                        context.localize("command.channel.add.message.added",
                                Replacement.create("CHANNEL", addedChannel)))
-               .mention(Collections.emptyList())
+               .setAllowedMentions(Collections.emptyList())
                .queue();
         return Result.freeze();
     }

--- a/src/main/java/de/chojo/repbot/service/RoleAssigner.java
+++ b/src/main/java/de/chojo/repbot/service/RoleAssigner.java
@@ -4,7 +4,6 @@ import de.chojo.jdautil.localization.ILocalizer;
 import de.chojo.jdautil.localization.util.Replacement;
 import de.chojo.jdautil.wrapper.EventContext;
 import de.chojo.repbot.dao.provider.Guilds;
-import de.chojo.repbot.dao.snapshots.RepProfile;
 import de.chojo.repbot.dao.snapshots.ReputationRank;
 import de.chojo.repbot.util.Roles;
 import net.dv8tion.jda.api.entities.Guild;
@@ -22,7 +21,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -57,7 +55,7 @@ public class RoleAssigner {
         } catch (RoleAccessException e) {
             channel.sendMessage(localizer.localize("error.roleAccess", channel.getGuild(),
                            Replacement.createMention("ROLE", e.role())))
-                   .mention(Collections.emptyList())
+                   .setAllowedMentions(Collections.emptyList())
                    .queue();
         }
         return Optional.empty();

--- a/src/main/java/de/chojo/repbot/service/reputation/ReputationService.java
+++ b/src/main/java/de/chojo/repbot/service/reputation/ReputationService.java
@@ -234,7 +234,7 @@ public class ReputationService {
             if (channel == null || rank.getRole(guild) == null) return;
             channel.sendMessage(localizer.localize("message.levelAnnouncement", guild,
                            Replacement.createMention(receiver), Replacement.createMention(rank.getRole(guild))))
-                   .mention(Collections.emptyList())
+                   .setAllowedMentions(Collections.emptyList())
                    .queue();
         });
         return true;


### PR DESCRIPTION
**Checklist**
- [ ] I made changes to commands
  - [ ] I fully localised the command
  - [ ] I fully checked the commands functionality

- [ ] I added new localisation codes
  - [ ] I fully translated it for all languages
  - [ ] I sorted properties alphabetically


- [ ] I made changes to the database
  - [ ] I added my changed to a patch file
  - [ ] I made sure my database was up to date
  - [ ] I checked that the migration works

- [x] I made changes to internal structure 


**Short Description**
We pinged users or roles when we shouldn't have pinged them

**Detailed Description**
Some parts of the code use `.mention(Collections.emptyList())` instead of `.setAllowedMentions(Collections.emptyList())`.

`.mention` however only has an effect after we have set `.setAllowedMentions` and gives us the ability to define exceptions for pinging users or roles which would be excluded by `.setAllowedMentions`.
  
