### PR TITLE
Add command to invalidate guild cache

### DIFF
--- a/src/main/java/de/chojo/repbot/commands/bot/BotAdmin.java
+++ b/src/main/java/de/chojo/repbot/commands/bot/BotAdmin.java
@@ -6,6 +6,7 @@ import de.chojo.jdautil.interactions.slash.Slash;
 import de.chojo.jdautil.interactions.slash.SubCommand;
 import de.chojo.jdautil.interactions.slash.provider.SlashCommand;
 import de.chojo.repbot.commands.bot.handler.Debug;
+import de.chojo.repbot.commands.bot.handler.InvalidateCache;
 import de.chojo.repbot.commands.bot.handler.Leave;
 import de.chojo.repbot.commands.bot.handler.Redeploy;
 import de.chojo.repbot.commands.bot.handler.Search;
@@ -53,6 +54,9 @@ public class BotAdmin extends SlashCommand {
                 .subCommand(SubCommand.of("search", "Search for guilds")
                         .handler(new Search())
                         .argument(Argument.text("term", "Search term").asRequired()))
+                .subCommand(SubCommand.of("invalidate_cache", "Invalidates cached data for the guild")
+                        .handler(new InvalidateCache(guilds))
+                        .argument(Argument.text("guild", "guild id").asRequired()))
                 .subCommand(SubCommand.of("leave", "Leave a guild")
                         .handler(new Leave())
                         .argument(Argument.text("guild_id", "Guild id").asRequired())));

--- a/src/main/java/de/chojo/repbot/commands/bot/handler/InvalidateCache.java
+++ b/src/main/java/de/chojo/repbot/commands/bot/handler/InvalidateCache.java
@@ -1,0 +1,21 @@
+package de.chojo.repbot.commands.bot.handler;
+
+import de.chojo.jdautil.interactions.slash.structure.handler.SlashHandler;
+import de.chojo.jdautil.wrapper.EventContext;
+import de.chojo.repbot.dao.provider.Guilds;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+
+public class InvalidateCache implements SlashHandler {
+
+    private final Guilds guilds;
+
+    public InvalidateCache(Guilds guilds) {
+        this.guilds = guilds;
+    }
+
+    @Override
+    public void onSlashCommand(SlashCommandInteractionEvent event, EventContext context) {
+        guilds.invalidate(event.getOption("guild").getAsLong());
+        event.reply("Invalidated guild cache").queue();
+    }
+}

--- a/src/main/java/de/chojo/repbot/dao/provider/Guilds.java
+++ b/src/main/java/de/chojo/repbot/dao/provider/Guilds.java
@@ -89,4 +89,8 @@ public class Guilds extends QueryFactory {
                 .readRow(row -> byId(row.getLong("guild_id")))
                 .allSync();
     }
+
+    public void invalidate(long guild) {
+        guilds.invalidate(guild);
+    }
 }


### PR DESCRIPTION
**Checklist**
- [x] I made changes to commands
  - [ ] I fully localised the command
  - [ ] I fully checked the commands functionality

- [ ] I added new localisation codes
  - [ ] I fully translated it for all languages
  - [ ] I sorted properties alphabetically


- [ ] I made changes to the database
  - [ ] I added my changed to a patch file
  - [ ] I made sure my database was up to date
  - [ ] I checked that the migration works

- [ ] I made changes to internal structure 


**Short Description**
Allows to invalidate guild settings without restarting