### PR TITLE
Fix exception when the user leveled up inside a news channel due to repadmin

### DIFF
--- a/src/main/java/de/chojo/repbot/commands/repadmin/handler/reputation/BaseReputationModifier.java
+++ b/src/main/java/de/chojo/repbot/commands/repadmin/handler/reputation/BaseReputationModifier.java
@@ -26,7 +26,7 @@ public abstract class BaseReputationModifier implements SlashHandler {
         var add = event.getOption("amount").getAsLong();
         execute(event, context, user, repUser, add);
         var member = event.getGuild().retrieveMember(user).complete();
-        roleAssigner.updateReporting(member, event.getChannel().asTextChannel());
+        roleAssigner.updateReporting(member, event.getChannel().asGuildMessageChannel());
     }
 
     abstract void execute(SlashCommandInteractionEvent event, EventContext context, User user, RepUser repUser, long rep);


### PR DESCRIPTION
**Checklist**
- [ ] I made changes to commands
  - [ ] I fully localised the command
  - [ ] I fully checked the commands functionality

- [ ] I added new localisation codes
  - [ ] I fully translated it for all languages
  - [ ] I sorted properties alphabetically


- [ ] I made changes to the database
  - [ ] I added my changed to a patch file
  - [ ] I made sure my database was up to date
  - [ ] I checked that the migration works

- [x] I made changes to internal structure 


**Short Description**
Fixes an exception when a level up was triggered by repadmin in a news channel
