### PR TITLE
Cache thankword patterns and add analysis timeout

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,5 @@
 rootProject.name = "rep-bot"
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+}

--- a/src/main/java/de/chojo/repbot/dao/access/guild/settings/sub/thanking/Thankwords.java
+++ b/src/main/java/de/chojo/repbot/dao/access/guild/settings/sub/thanking/Thankwords.java
@@ -28,6 +28,9 @@ public class Thankwords extends QueryFactory implements GuildHolder {
         this.thanking = thanking;
         this.thankwords = thankwords;
         this.lock = new StampedLock();
+        // as 'this' does not escape in this constructor,
+        // we don't need a write-lock here
+        this.cachedPattern = compilePattern();
     }
 
     @Override
@@ -56,7 +59,7 @@ public class Thankwords extends QueryFactory implements GuildHolder {
     }
 
     /**
-     * Must be called in a write-lock
+     * Must be called in a write-lock if 'this' is accessible from other objects
      */
     private Pattern compilePattern() {
         if (thankwords.isEmpty()) return Pattern.compile("");

--- a/src/main/java/de/chojo/repbot/dao/access/guild/settings/sub/thanking/Thankwords.java
+++ b/src/main/java/de/chojo/repbot/dao/access/guild/settings/sub/thanking/Thankwords.java
@@ -7,6 +7,7 @@ import net.dv8tion.jda.api.entities.Guild;
 import org.intellij.lang.annotations.Language;
 
 import java.util.Set;
+import java.util.concurrent.locks.StampedLock;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -19,11 +20,14 @@ public class Thankwords extends QueryFactory implements GuildHolder {
     private final Thanking thanking;
 
     private final Set<String> thankwords;
+    private final StampedLock lock;
+    private volatile Pattern cachedPattern;
 
     public Thankwords(Thanking thanking, Set<String> thankwords) {
         super(thanking);
         this.thanking = thanking;
         this.thankwords = thankwords;
+        this.lock = new StampedLock();
     }
 
     @Override
@@ -37,53 +41,76 @@ public class Thankwords extends QueryFactory implements GuildHolder {
     }
 
     public Set<String> words() {
-        return thankwords;
+        long stamp = lock.readLock();
+        try {
+            return Set.copyOf(thankwords);
+        } finally {
+            lock.unlockRead(stamp);
+        }
     }
 
     public Pattern thankwordPattern() {
+        // even if another thread has a write-lock, we either read the old pattern before the other thread compiles the new one,
+        // or we read the new one - both fine for our use
+        return cachedPattern;
+    }
+
+    /**
+     * Must be called in a write-lock
+     */
+    private Pattern compilePattern() {
         if (thankwords.isEmpty()) return Pattern.compile("");
         var twPattern = thankwords.stream()
-                                  .map(t -> String.format(THANKWORD, t))
-                                  .collect(Collectors.joining("|"));
+                .map(t -> String.format(THANKWORD, t))
+                .collect(Collectors.joining("|"));
         return Pattern.compile(String.format(PATTERN, twPattern),
                 Pattern.CASE_INSENSITIVE + Pattern.MULTILINE + Pattern.DOTALL + Pattern.COMMENTS);
     }
 
     public boolean add(String pattern) {
-        var result = builder()
-                .query("""
-                       INSERT INTO
-                           thankwords(guild_id, thankword) VALUES(?,?)
-                               ON CONFLICT(guild_id, thankword)
-                                   DO NOTHING;
-                       """)
-                .parameter(stmt -> stmt.setLong(guildId()).setString(pattern))
-                .update()
-                .sendSync()
-                .changed();
-        if (result) {
-            thankwords.add(pattern);
+        long stamp = lock.writeLock();
+        try {
+            var result = builder().query("""
+                    INSERT INTO
+                        thankwords(guild_id, thankword) VALUES(?,?)
+                            ON CONFLICT(guild_id, thankword)
+                                DO NOTHING;
+                    """)
+                    .parameter(stmt -> stmt.setLong(guildId()).setString(pattern))
+                    .update()
+                    .sendSync()
+                    .changed();
+            if (result) {
+                thankwords.add(pattern);
+                cachedPattern = compilePattern();
+            }
+            return result;
+        } finally {
+            lock.unlockWrite(stamp);
         }
-        return result;
     }
 
     public boolean remove(String pattern) {
-        var result = builder()
-                .query("""
-                       DELETE FROM
-                           thankwords
-                       WHERE
-                           guild_id = ?
-                           AND thankword = ?
-                       """)
-                .parameter(stmt -> stmt.setLong(guildId()).setString(pattern))
-                .update()
-                .sendSync()
-                .changed();
-        if (result) {
-            thankwords.remove(pattern);
+        long stamp = lock.writeLock();
+        try {
+            var result = builder().query("""
+                    DELETE FROM
+                        thankwords
+                    WHERE
+                        guild_id = ?
+                        AND thankword = ?
+                    """).parameter(stmt -> stmt.setLong(guildId()).setString(pattern))
+                    .update()
+                    .sendSync()
+                    .changed();
+            if (result) {
+                thankwords.remove(pattern);
+                cachedPattern = compilePattern();
+            }
+            return result;
+        } finally {
+            lock.unlockWrite(stamp);
         }
-        return result;
     }
 
     public String prettyString() {


### PR DESCRIPTION
**Checklist**
- [ ] I made changes to commands
  - [ ] I fully localised the command
  - [ ] I fully checked the commands functionality

- [ ] I added new localisation codes
  - [ ] I fully translated it for all languages
  - [ ] I sorted properties alphabetically


- [ ] I made changes to the database
  - [ ] I added my changed to a patch file
  - [ ] I made sure my database was up to date
  - [ ] I checked that the migration works

- [ ] I made changes to internal structure 


**Short Description**
<!-- Describe the changes you made in a short fashion-->

Avoid unnecessary recompilation of thankword patterns and add a timeout to thankword analysis.

**Detailed Description**
<!-- Add additional information to your pull request -->

Thankwords rarely change, so caching the pattern is benefitial. Additionally, limiting the time a pattern can take to find matches avoids running into non-responsive situations.
  
