### PR TITLE
Fix channel ignored when channel list is empty and blacklisted

### DIFF
--- a/src/main/java/de/chojo/repbot/dao/access/guild/settings/sub/thanking/Channels.java
+++ b/src/main/java/de/chojo/repbot/dao/access/guild/settings/sub/thanking/Channels.java
@@ -67,20 +67,12 @@ public class Channels extends QueryFactory implements GuildHolder {
     }
 
     public boolean isEnabledByChannel(StandardGuildChannel channel) {
-        if (channels.isEmpty()) return false;
-        if (isWhitelist()) {
-            return channels.contains(channel.getIdLong());
-        }
-        return !channels.contains(channel.getIdLong());
+        return isWhitelist() == channels.contains(channel.getIdLong());
     }
 
     public boolean isEnabledByCategory(@Nullable Category category) {
         if (category == null) return false;
-        if (categories.isEmpty()) return false;
-        if (isWhitelist()) {
-            return categories.contains(category.getIdLong());
-        }
-        return !categories.contains(category.getIdLong());
+        return isWhitelist() == categories.contains(category.getIdLong());
     }
 
     public List<GuildChannel> channels() {


### PR DESCRIPTION
**Checklist**
- [ ] I made changes to commands
  - [ ] I fully localised the command
  - [ ] I fully checked the commands functionality

- [ ] I added new localisation codes
  - [ ] I fully translated it for all languages
  - [ ] I sorted properties alphabetically


- [ ] I made changes to the database
  - [ ] I added my changed to a patch file
  - [ ] I made sure my database was up to date
  - [ ] I checked that the migration works

- [x] I made changes to internal structure 


**Short Description**
For some reason stuff failed when the blacklist was enabled, but the channel list was empty, because we always returned false when the channel list was empty even when using the blacklist. After some consideration we noticed that this can be simplified by a lot.
  
