### PR TITLE
Mark setup command as adminCommand

### DIFF
--- a/src/main/java/de/chojo/repbot/commands/setup/Setup.java
+++ b/src/main/java/de/chojo/repbot/commands/setup/Setup.java
@@ -22,6 +22,7 @@ public class Setup extends SlashCommand {
     public Setup(Guilds guilds, ThankwordsContainer thankwordsContainer, Configuration configuration) {
         super(Slash.of("setup", "command.setup.description")
                 .guildOnly()
+                .adminCommand()
                 .command(new Start(guilds, thankwordsContainer, configuration)));
     }
 


### PR DESCRIPTION
**Checklist**
- [ ] I made changes to commands
  - [ ] I fully localised the command
  - [ ] I fully checked the commands functionality

- [ ] I added new localisation codes
  - [ ] I fully translated it for all languages
  - [ ] I sorted properties alphabetically


- [ ] I made changes to the database
  - [ ] I added my changed to a patch file
  - [ ] I made sure my database was up to date
  - [ ] I checked that the migration works

- [x] I made changes to internal structure 


**Short Description**
The setup command was not marked as adminCommand. That means that by default, everyone can use the setup command which is not intended.

