### PR TITLE
Enhance gdpr logging and user prune performance

### DIFF
--- a/src/main/java/de/chojo/repbot/commands/gdpr/handler/Delete.java
+++ b/src/main/java/de/chojo/repbot/commands/gdpr/handler/Delete.java
@@ -4,9 +4,13 @@ import de.chojo.jdautil.interactions.slash.structure.handler.SlashHandler;
 import de.chojo.jdautil.wrapper.EventContext;
 import de.chojo.repbot.dao.access.Gdpr;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import org.slf4j.Logger;
+
+import static org.slf4j.LoggerFactory.getLogger;
 
 public class Delete implements SlashHandler {
     private final Gdpr gdpr;
+    private static final Logger log = getLogger(Delete.class);
 
     public Delete(Gdpr gdpr) {
         this.gdpr = gdpr;

--- a/src/main/java/de/chojo/repbot/commands/prune/handler/Guild.java
+++ b/src/main/java/de/chojo/repbot/commands/prune/handler/Guild.java
@@ -5,8 +5,12 @@ import de.chojo.jdautil.localization.util.Replacement;
 import de.chojo.jdautil.wrapper.EventContext;
 import de.chojo.repbot.service.GdprService;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import org.slf4j.Logger;
+
+import static org.slf4j.LoggerFactory.getLogger;
 
 public class Guild implements SlashHandler {
+    private static final Logger log = getLogger(Guild.class);
     private final GdprService service;
 
     public Guild(GdprService service) {

--- a/src/main/java/de/chojo/repbot/dao/access/gdpr/GdprUser.java
+++ b/src/main/java/de/chojo/repbot/dao/access/gdpr/GdprUser.java
@@ -45,6 +45,7 @@ public class GdprUser extends QueryFactory {
     }
 
     public boolean queueDeletion() {
+        log.info("User {} requested deletion of their data", userId());
         return builder()
                 .query("""
                        INSERT INTO

--- a/src/main/java/de/chojo/repbot/dao/access/guild/reputation/sub/user/Gdpr.java
+++ b/src/main/java/de/chojo/repbot/dao/access/guild/reputation/sub/user/Gdpr.java
@@ -7,9 +7,13 @@ import de.chojo.sadu.base.QueryFactory;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.User;
+import org.slf4j.Logger;
+
+import static org.slf4j.LoggerFactory.getLogger;
 
 public class Gdpr extends QueryFactory implements MemberHolder {
     private final RepUser repUser;
+    private static final Logger log = getLogger(Gdpr.class);
 
     public Gdpr(RepUser repUser) {
         super(repUser);
@@ -22,6 +26,7 @@ public class Gdpr extends QueryFactory implements MemberHolder {
     }
 
     public void queueDeletion() {
+        log.info("User {} is scheduled for deletion on guild {}", userId(), guildId());
         builder()
                 .query("""
                        INSERT INTO
@@ -38,6 +43,7 @@ public class Gdpr extends QueryFactory implements MemberHolder {
     }
 
     public void dequeueDeletion() {
+        log.info("User {} deletion on guild {} canceled", userId(), guildId());
         builder()
                 .query("""
                        DELETE FROM


### PR DESCRIPTION
**Checklist**
- [ ] I made changes to commands
  - [ ] I fully localised the command
  - [ ] I fully checked the commands functionality

- [ ] I added new localisation codes
  - [ ] I fully translated it for all languages
  - [ ] I sorted properties alphabetically


- [ ] I made changes to the database
  - [ ] I added my changed to a patch file
  - [ ] I made sure my database was up to date
  - [ ] I checked that the migration works

- [x] I made changes to internal structure 


**Short Description**
We had nearly no logging for the gdpr actions we take. User deletion was queued without any possibility to track those changes.
  
