### PR TITLE
Remove slash from command to get the same style in the tags

### DIFF
--- a/tags/analyzer_log.md
+++ b/tags/analyzer_log.md
@@ -1,7 +1,7 @@
 ### Why did user XY not receive any reputation or why was the message ignored?
 
 This can have a lot of reasons and since it is nearly impossible for us to cover all the reasons here, we added 
-a command which can tell exactly this. The `/analyzer log <message_id>` command will show you in detail how the 
+a command which can tell exactly this. The `analyzer log <message_id>` command will show you in detail how the 
 bot processed a message.
 
 This command is basically showing what the debug emojis are showing as well, but will actually explain why 


### PR DESCRIPTION
**Checklist**
- [ X ] I edited a tags file

**Short Description**
All commands in the tags were written without the slash.
  
