### PR TITLE
Fix analyzer command

### DIFF
--- a/src/main/java/de/chojo/repbot/commands/log/handler/BaseAnalyzer.java
+++ b/src/main/java/de/chojo/repbot/commands/log/handler/BaseAnalyzer.java
@@ -14,7 +14,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 
 public class BaseAnalyzer {
     public void onSlashCommand(SlashCommandInteractionEvent event, EventContext context, Reputation reputation) {
-        var optMessageId = ValueParser.parseLong(event.getOption("message_id").getAsString());
+        var optMessageId = ValueParser.parseLong(event.getOption("messageid").getAsString());
         if (optMessageId.isEmpty()) {
             event.reply(context.localize("error.invalidMessage")).setEphemeral(true).queue();
             return;


### PR DESCRIPTION
**Checklist**
- [x] I made changes to commands
  - [ ] I fully localised the command
  - [ ] I fully checked the commands functionality

- [ ] I added new localisation codes
  - [ ] I fully translated it for all languages
  - [ ] I sorted properties alphabetically


- [ ] I made changes to the database
  - [ ] I added my changed to a patch file
  - [ ] I made sure my database was up to date
  - [ ] I checked that the migration works

- [ ] I made changes to internal structure 


**Short Description**
<!-- Describe the changes you made in a short fashion-->
The parameter name of the command and the retrieving code do not match and cause errors.


**Detailed Description**
Parameter name on the command: https://github.com/rainbowdashlabs/reputation-bot/blob/61e3c4c6999e6d5bb2527c875d01cb3249ebbff6/src/main/java/de/chojo/repbot/commands/log/Log.java#L33-L35

Parameter name where we retrieve the value: https://github.com/rainbowdashlabs/reputation-bot/blob/61e3c4c6999e6d5bb2527c875d01cb3249ebbff6/src/main/java/de/chojo/repbot/commands/log/handler/BaseAnalyzer.java#L17


