### PR TITLE
feature: Switch reset_date to timestamp with UTC

### DIFF
--- a/src/main/java/de/chojo/repbot/commands/repadmin/RepAdmin.java
+++ b/src/main/java/de/chojo/repbot/commands/repadmin/RepAdmin.java
@@ -17,6 +17,7 @@ import de.chojo.repbot.commands.repadmin.handler.reputation.Set;
 import de.chojo.repbot.commands.repadmin.handler.resetdate.CurrentResetDate;
 import de.chojo.repbot.commands.repadmin.handler.resetdate.RemoveResetDate;
 import de.chojo.repbot.commands.repadmin.handler.resetdate.SetResetDate;
+import de.chojo.repbot.commands.repadmin.handler.resetdate.SetResetDateNow;
 import de.chojo.repbot.config.Configuration;
 import de.chojo.repbot.dao.provider.GuildRepository;
 import de.chojo.repbot.service.PremiumService;
@@ -76,7 +77,9 @@ public class RepAdmin extends SlashCommand {
                                .subCommand(SubCommand.of("remove", "command.repadmin.resetdate.remove.description")
                                                      .handler(new RemoveResetDate(guildRepository)))
                                .subCommand(SubCommand.of("current", "command.repadmin.resetdate.current.description")
-                                                     .handler(new CurrentResetDate(guildRepository))))
+                                                     .handler(new CurrentResetDate(guildRepository)))
+                               .subCommand(SubCommand.of("now", "command.repadmin.resetdate.now.description")
+                                                     .handler(new SetResetDateNow(guildRepository))))
                    .subCommand(SubCommand.of("profile", "command.repadmin.profile.description")
                                          .handler(new Profile(guildRepository, configuration))
                                          .argument(Argument.user("user", "command.repadmin.profile.options.user.description").asRequired()))

--- a/src/main/java/de/chojo/repbot/commands/repadmin/handler/resetdate/SetResetDateNow.java
+++ b/src/main/java/de/chojo/repbot/commands/repadmin/handler/resetdate/SetResetDateNow.java
@@ -1,0 +1,27 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) RainbowDashLabs and Contributor
+ */
+package de.chojo.repbot.commands.repadmin.handler.resetdate;
+
+import de.chojo.jdautil.interactions.slash.structure.handler.SlashHandler;
+import de.chojo.jdautil.wrapper.EventContext;
+import de.chojo.repbot.dao.provider.GuildRepository;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+
+public class SetResetDateNow implements SlashHandler {
+    private final GuildRepository guildRepository;
+
+    public SetResetDateNow(GuildRepository guildRepository) {
+        this.guildRepository = guildRepository;
+    }
+
+    @Override
+    public void onSlashCommand(SlashCommandInteractionEvent event, EventContext context) {
+        guildRepository.guild(event.getGuild()).settings().general().resetDateNow();
+
+        event.reply(context.localize("command.repadmin.resetdate.now.message.set"))
+             .setEphemeral(true).complete();
+    }
+}

--- a/src/main/resources/database/postgresql/1/patch_37.sql
+++ b/src/main/resources/database/postgresql/1/patch_37.sql
@@ -1,0 +1,3 @@
+ALTER TABLE repbot_schema.guild_settings
+ALTER COLUMN reset_date TYPE TIMESTAMP;
+


### PR DESCRIPTION
1.Changed reset_date column from DATE to TIMESTAMP in database 2.Converted LocalDate inputs to UTC midnight timestamps 3.Added resetDateNow() method for current UTC timestamp 4.Added /repadmin resetdate now subcommand for immediate reset

**Checklist**
- [x] I made changes to commands
  - [x] I fully localised the command
  - [ ] I fully checked the commands functionality

- [x] I added new localisation codes
  - [x] I fully translated it for all languages
  - [x] I sorted properties alphabetically


- [x] I made changes to the database
  - [x] I added my changed to a patch file
  - [x] I made sure my database was up to date
  - [x] I checked that the migration works

- [ ] I made changes to internal structure 


**Short Description**
<!-- Describe the changes you made in a short fashion-->

**Detailed Description**
<!-- Add additional information to your pull request -->


<!-- Add your issue number here or delete this part if this PR is not related to an issue -->
Closes #<issuenumber>
  
