### PR TITLE
Fix user settings page failures

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = "de.chojo"
-version = "2.8.1"
+version = "2.8.2"
 
 repositories {
     mavenLocal()

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -25,6 +25,7 @@ class ApiClient {
 
         this.axiosInstance = axios.create({
             baseURL: baseURL,
+            timeout: 30000,
         });
 
         this.axiosInstance.interceptors.request.use((config) => {
@@ -84,8 +85,13 @@ class ApiClient {
                 }
 
                 if (error.response?.data) {
-                    // Backend returned an ApiErrorResponse
-                    errorStore.addError(error.response.data);
+                    // Backend returned an ApiErrorResponse or a plain text error
+                    const data = error.response.data;
+                    if (typeof data === 'string') {
+                        errorStore.addError({error: 'Request Failed', message: data});
+                    } else {
+                        errorStore.addError(data);
+                    }
                 } else if (error.request) {
                     // Request was made but no response received
                     errorStore.addError({
@@ -653,7 +659,7 @@ class ApiClient {
     }
 
     public async updateUserVoteGuild(voteGuild: string): Promise<void> {
-        await this.axiosInstance.patch('/user/settings/voteguild', { voteGuild: Number(voteGuild) });
+        await this.axiosInstance.patch('/user/settings/voteguild', { voteGuild });
     }
 
     public async updateUserPublicProfile(publicProfile: boolean): Promise<void> {

--- a/frontend/src/views/user/UserSettingsView.vue
+++ b/frontend/src/views/user/UserSettingsView.vue
@@ -29,8 +29,10 @@ const guilds = computed(() => {
 onMounted(async () => {
   try {
     const settings = await api.getUserSettings()
-    voteGuild.value = settings.voteGuild
+    voteGuild.value = String(settings.voteGuild)
     publicProfile.value = settings.publicProfile
+    savedVoteGuild = voteGuild.value
+    savedPublicProfile = publicProfile.value
   } catch (error) {
     console.error('Failed to fetch user settings:', error)
   } finally {
@@ -38,19 +40,26 @@ onMounted(async () => {
   }
 })
 
+let savedVoteGuild = '0'
+let savedPublicProfile = false
+
 const updateVoteGuild = async () => {
   try {
     await api.updateUserVoteGuild(voteGuild.value)
+    savedVoteGuild = voteGuild.value
   } catch (error) {
     console.error('Failed to update vote guild:', error)
+    voteGuild.value = savedVoteGuild
   }
 }
 
 const updatePublicProfile = async () => {
   try {
     await api.updateUserPublicProfile(publicProfile.value)
+    savedPublicProfile = publicProfile.value
   } catch (error) {
     console.error('Failed to update public profile:', error)
+    publicProfile.value = savedPublicProfile
   }
 }
 </script>

--- a/src/main/java/de/chojo/repbot/dao/access/user/RepUser.java
+++ b/src/main/java/de/chojo/repbot/dao/access/user/RepUser.java
@@ -50,7 +50,7 @@ public class RepUser {
     public UserSettings settings() {
         if (settings == null) {
             settings = query("""
-                    SELECT id, vote_guild FROM user_settings WHERE id = ?
+                    SELECT id, vote_guild, public_profile FROM user_settings WHERE id = ?
                     """)
                     .single(call().bind(id))
                     .mapAs(UserSettings.class)

--- a/src/main/java/de/chojo/repbot/web/routes/v1/user/UserSettingsRoute.java
+++ b/src/main/java/de/chojo/repbot/web/routes/v1/user/UserSettingsRoute.java
@@ -12,6 +12,7 @@ import de.chojo.repbot.dao.provider.UserRepository;
 import de.chojo.repbot.service.MailService;
 import de.chojo.repbot.web.config.Role;
 import de.chojo.repbot.web.config.SessionAttribute;
+import de.chojo.repbot.web.error.ErrorResponseWrapper;
 import de.chojo.repbot.web.pojo.user.MailEntryPOJO;
 import de.chojo.repbot.web.pojo.user.UserSettingsPOJO;
 import de.chojo.repbot.web.routes.RoutesBuilder;
@@ -92,7 +93,10 @@ public class UserSettingsRoute implements RoutesBuilder {
         UserSettingsPOJO body = ctx.bodyAsClass(UserSettingsPOJO.class);
 
         if (body.voteGuild() != 0 && !session.guilds().containsKey(String.valueOf(body.voteGuild()))) {
-            ctx.status(400).result("Guild not in session");
+            ctx.status(400)
+                    .json(new ErrorResponseWrapper(
+                            "Guild not in session",
+                            "The guild %d is not part of your session.".formatted(body.voteGuild())));
             return;
         }
 
@@ -115,7 +119,10 @@ public class UserSettingsRoute implements RoutesBuilder {
         UpdateVoteGuildPOJO body = ctx.bodyAsClass(UpdateVoteGuildPOJO.class);
 
         if (body.voteGuild() != 0 && !session.guilds().containsKey(String.valueOf(body.voteGuild()))) {
-            ctx.status(400).result("Guild not in session");
+            ctx.status(400)
+                    .json(new ErrorResponseWrapper(
+                            "Guild not in session",
+                            "The guild %d is not part of your session.".formatted(body.voteGuild())));
             return;
         }
 

--- a/src/main/java/de/chojo/repbot/web/services/DiscordOAuthService.java
+++ b/src/main/java/de/chojo/repbot/web/services/DiscordOAuthService.java
@@ -23,14 +23,18 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 public class DiscordOAuthService {
     private static final String DISCORD_BASE = "https://discord.com";
     private static final String DISCORD_API = DISCORD_BASE + "/api/";
-    private final HttpClient httpClient = HttpClient.newHttpClient();
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+    private final HttpClient httpClient =
+            HttpClient.newBuilder().connectTimeout(REQUEST_TIMEOUT).build();
     private final ObjectMapper mapper =
             new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     private final Configuration configuration;
@@ -75,6 +79,7 @@ public class DiscordOAuthService {
                 .uri(URI.create(DISCORD_API + "/oauth2/token"))
                 .header("Content-Type", "application/x-www-form-urlencoded")
                 .header("Authorization", basicAuth(cfg().clientId(), cfg().clientSecret()))
+                .timeout(REQUEST_TIMEOUT)
                 .POST(HttpRequest.BodyPublishers.ofString(form))
                 .build();
         HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
@@ -84,35 +89,41 @@ public class DiscordOAuthService {
         return mapper.readValue(response.body(), DiscordTokenResponse.class).toTokenResponse();
     }
 
-    public synchronized DiscordUser getCurrentUser(String accessToken) throws IOException, InterruptedException {
-        DiscordUser cached = userCache.getIfPresent(accessToken);
-        if (cached != null) {
-            return cached;
+    public DiscordUser getCurrentUser(String accessToken) throws IOException, InterruptedException {
+        try {
+            return userCache.get(accessToken, () -> fetchCurrentUser(accessToken));
+        } catch (ExecutionException e) {
+            throw unwrap(e);
         }
+    }
 
+    private DiscordUser fetchCurrentUser(String accessToken) throws IOException, InterruptedException {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(DISCORD_API + "/users/@me"))
                 .header("Authorization", "Bearer " + accessToken)
+                .timeout(REQUEST_TIMEOUT)
                 .GET()
                 .build();
         HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         if (response.statusCode() / 100 != 2) {
             throw new IOException("Discord /users/@me failed: " + response.statusCode() + " - " + response.body());
         }
-        DiscordUser user = mapper.readValue(response.body(), DiscordUser.class);
-        userCache.put(accessToken, user);
-        return user;
+        return mapper.readValue(response.body(), DiscordUser.class);
     }
 
-    public synchronized List<DiscordGuild> getUserGuilds(String accessToken) throws IOException, InterruptedException {
-        List<DiscordGuild> cached = userGuildsCache.getIfPresent(accessToken);
-        if (cached != null) {
-            return cached;
+    public List<DiscordGuild> getUserGuilds(String accessToken) throws IOException, InterruptedException {
+        try {
+            return userGuildsCache.get(accessToken, () -> fetchUserGuilds(accessToken));
+        } catch (ExecutionException e) {
+            throw unwrap(e);
         }
+    }
 
+    private List<DiscordGuild> fetchUserGuilds(String accessToken) throws IOException, InterruptedException {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(DISCORD_API + "/users/@me/guilds"))
                 .header("Authorization", "Bearer " + accessToken)
+                .timeout(REQUEST_TIMEOUT)
                 .GET()
                 .build();
         HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
@@ -120,9 +131,18 @@ public class DiscordOAuthService {
             throw new IOException(
                     "Discord /users/@me/guilds failed: " + response.statusCode() + " - " + response.body());
         }
-        List<DiscordGuild> guilds = mapper.readValue(response.body(), new TypeReference<>() {});
-        userGuildsCache.put(accessToken, guilds);
-        return guilds;
+        return mapper.readValue(response.body(), new TypeReference<>() {});
+    }
+
+    private static IOException unwrap(ExecutionException e) throws InterruptedException {
+        Throwable cause = e.getCause();
+        if (cause instanceof InterruptedException interrupted) {
+            throw interrupted;
+        }
+        if (cause instanceof IOException io) {
+            return io;
+        }
+        return new IOException(cause);
     }
 
     /**
@@ -141,6 +161,7 @@ public class DiscordOAuthService {
                 .uri(URI.create(DISCORD_API + "/oauth2/token/revoke"))
                 .header("Content-Type", "application/x-www-form-urlencoded")
                 .header("Authorization", basicAuth(cfg().clientId(), cfg().clientSecret()))
+                .timeout(REQUEST_TIMEOUT)
                 .POST(HttpRequest.BodyPublishers.ofString(form))
                 .build();
         HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());

--- a/src/main/java/de/chojo/repbot/web/services/SessionService.java
+++ b/src/main/java/de/chojo/repbot/web/services/SessionService.java
@@ -184,7 +184,10 @@ public class SessionService {
         // Build member info for the current user (global, not guild-scoped)
         MemberPOJO memberPojo;
         try {
-            User user = shardManager.retrieveUserById(userId).complete();
+            User user = shardManager
+                    .retrieveUserById(userId)
+                    .timeout(10, TimeUnit.SECONDS)
+                    .complete();
             if (user != null) {
                 memberPojo =
                         new MemberPOJO(user.getName(), String.valueOf(userId), "#ffffff", user.getEffectiveAvatarUrl());
@@ -218,7 +221,9 @@ public class SessionService {
 
             Member member;
             try {
-                member = guild.retrieveMemberById(userId).complete();
+                member = guild.retrieveMemberById(userId)
+                        .timeout(10, TimeUnit.SECONDS)
+                        .complete();
             } catch (Exception e) {
                 log.error(
                         LogNotify.NOTIFY_ADMIN,

--- a/src/test/java/de/chojo/repbot/dao/access/guild/settings/sub/thanking/ThankwordPatternTest.java
+++ b/src/test/java/de/chojo/repbot/dao/access/guild/settings/sub/thanking/ThankwordPatternTest.java
@@ -1,0 +1,78 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) RainbowDashLabs and Contributor
+ */
+package de.chojo.repbot.dao.access.guild.settings.sub.thanking;
+
+import de.chojo.repbot.dao.access.guild.settings.sub.Thanking;
+import de.chojo.repbot.dao.components.GuildHolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+
+class ThankwordPatternTest {
+
+    private static Thankwords thankwords(String... words) {
+        var thanking = new Thanking(null) {
+            @Override
+            public GuildHolder guildHolder() {
+                return this;
+            }
+
+            @Override
+            public long guildId() {
+                return 0;
+            }
+        };
+        return new Thankwords(thanking, new HashSet<>(Set.of(words)));
+    }
+
+    @Test
+    void matchesThankword() {
+        var pattern = thankwords("thanks", "ty").thankwordPattern();
+        var matcher = pattern.matcher("thanks a lot!");
+        Assertions.assertTrue(matcher.find());
+        Assertions.assertEquals("thanks", matcher.group("match"));
+    }
+
+    @Test
+    void matchesCaseInsensitive() {
+        var pattern = thankwords("thanks").thankwordPattern();
+        Assertions.assertTrue(pattern.matcher("THANKS mate").find());
+    }
+
+    @Test
+    void requiresWordBoundary() {
+        var pattern = thankwords("ty").thankwordPattern();
+        Assertions.assertFalse(pattern.matcher("empty message").find());
+        Assertions.assertTrue(pattern.matcher("ok ty!").find());
+    }
+
+    @Test
+    void emptyWordsYieldBlankPattern() {
+        Assertions.assertTrue(thankwords().thankwordPattern().pattern().isBlank());
+    }
+
+    @Test
+    void skipsWordsInvalidInRe2() {
+        // Lookahead is valid in java.util.regex but not in RE2. Legacy words like this must not break the guild.
+        var pattern = thankwords("(?=thanks)", "ty").thankwordPattern();
+        Assertions.assertTrue(pattern.matcher("ok ty!").find());
+        var onlyInvalid = thankwords("(?=thanks)").thankwordPattern();
+        Assertions.assertTrue(onlyInvalid.pattern().isBlank());
+    }
+
+    @Test
+    void catastrophicBacktrackingPatternMatchesInLinearTime() {
+        // (a+)+c against a long run of 'a's hangs java.util.regex for hours. RE2 must finish instantly.
+        var pattern = thankwords("(a+)+c").thankwordPattern();
+        var message = "a".repeat(10_000) + "b";
+        Assertions.assertTimeoutPreemptively(
+                Duration.ofSeconds(2),
+                () -> Assertions.assertFalse(pattern.matcher(message).find()));
+    }
+}


### PR DESCRIPTION
**Checklist**
- [ ] I made changes to commands
  - [ ] I fully localised the command
  - [ ] I fully checked the commands functionality

- [ ] I added new localisation codes
  - [ ] I fully translated it for all languages
  - [ ] I sorted properties alphabetically


- [ ] I made changes to the database
  - [ ] I added my changed to a patch file
  - [ ] I made sure my database was up to date
  - [ ] I checked that the migration works

- [ ] I made changes to internal structure 


**Short Description**
Send vote guild id as string to avoid JS number precision loss on snowflakes. Add timeouts to Discord OAuth and JDA calls and replace the service-wide lock with per-token cache loading so a stalled Discord request can no longer hang session reconstruction. Select the missing public_profile column so saved user settings actually load. Add an axios timeout and revert UI state on failed saves instead of spinning forever.

<!-- Add your issue number here or delete this part if this PR is not related to an issue -->
Closes #<issuenumber>
  
